### PR TITLE
feat: Alchemy tab — sacrifice & essence system (#117)

### DIFF
--- a/src/components/AlchemyTab.tsx
+++ b/src/components/AlchemyTab.tsx
@@ -231,7 +231,7 @@ export function AlchemyTab() {
             key={v}
             onClick={() => setView(v)}
             className={`
-              flex-1 py-1.5 rounded-[10px] text-xs font-semibold capitalize transition-all duration-150
+              flex-1 py-1.5 rounded-[10px] text-xs font-semibold text-center capitalize transition-all duration-150
               ${view === v
                 ? "bg-card text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground"

--- a/src/components/AlchemyTab.tsx
+++ b/src/components/AlchemyTab.tsx
@@ -1,0 +1,507 @@
+import { useState, useMemo } from "react";
+import { useGame } from "../store/GameContext";
+import { FLOWER_TYPES, RARITY_CONFIG, getFlower, MUTATIONS } from "../data/flowers";
+import { ESSENCE_YIELD, calculateEssenceYield, mergeEssences } from "../data/essences";
+import { sacrificeFlowers, type SacrificeEntry } from "../store/gameStore";
+import { edgeAlchemySacrifice } from "../lib/edgeFunctions";
+import type { MutationType, Rarity } from "../data/flowers";
+import type { EssenceItem } from "../data/essences";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+type SacrificeMap = Map<string, number>; // key: "speciesId||mutation"
+
+function mapKey(speciesId: string, mutation?: MutationType): string {
+  return `${speciesId}||${mutation ?? ""}`;
+}
+
+function parseKey(key: string): { speciesId: string; mutation?: MutationType } {
+  const [speciesId, mutStr] = key.split("||");
+  return { speciesId, mutation: (mutStr || undefined) as MutationType | undefined };
+}
+
+// ── Sub-component: Essence wallet ─────────────────────────────────────────
+
+function EssenceWallet({ essences }: { essences: EssenceItem[] }) {
+  if (essences.length === 0) {
+    return (
+      <div className="text-center py-4 text-xs text-muted-foreground">
+        No essences yet — sacrifice flowers to earn them.
+      </div>
+    );
+  }
+
+  // Sort by FLOWER_TYPES order for consistent display
+  const sorted = [...essences].sort((a, b) => {
+    const order = Object.keys(FLOWER_TYPES);
+    return order.indexOf(a.type) - order.indexOf(b.type);
+  });
+
+  return (
+    <div className="grid grid-cols-3 gap-1.5">
+      {sorted.map(({ type, amount }) => {
+        const cfg = FLOWER_TYPES[type];
+        return (
+          <div
+            key={type}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-xl border text-xs ${cfg.bgColor} ${cfg.borderColor}`}
+          >
+            <span className="text-sm shrink-0">{cfg.emoji}</span>
+            <div className="min-w-0">
+              <p className={`font-semibold leading-none ${cfg.color}`}>{amount}</p>
+              <p className="text-[10px] text-muted-foreground leading-none mt-0.5 truncate">{cfg.name}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Sub-component: Sacrifice preview strip ────────────────────────────────
+
+function SacrificePreview({ selections }: { selections: SacrificeMap }) {
+  const preview = useMemo(() => {
+    let acc: EssenceItem[] = [];
+    for (const [key, qty] of selections) {
+      if (qty <= 0) continue;
+      const { speciesId } = parseKey(key);
+      const flower = getFlower(speciesId);
+      if (!flower) continue;
+      const yields = calculateEssenceYield(flower.types, flower.rarity, qty);
+      acc = mergeEssences(acc, yields);
+    }
+    return acc;
+  }, [selections]);
+
+  if (preview.length === 0) return null;
+
+  return (
+    <div className="bg-card/60 border border-border rounded-xl px-3 py-2.5">
+      <p className="text-[10px] text-muted-foreground uppercase tracking-widest mb-2">
+        You will receive
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {preview.map(({ type, amount }) => {
+          const cfg = FLOWER_TYPES[type];
+          return (
+            <span
+              key={type}
+              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[11px] font-semibold ${cfg.bgColor} ${cfg.borderColor} ${cfg.color}`}
+            >
+              {cfg.emoji} {amount}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Main AlchemyTab component ─────────────────────────────────────────────
+
+type AlchemyView = "sacrifice" | "essences";
+
+export function AlchemyTab() {
+  const { state, perform } = useGame();
+
+  const [view, setView]           = useState<AlchemyView>("sacrifice");
+  const [selections, setSelections] = useState<SacrificeMap>(new Map());
+  const [activeRarity, setActiveRarity] = useState<Rarity | null>(null);
+  const [sacrificing, setSacrificing]   = useState(false);
+  const [error, setError]               = useState<string | null>(null);
+  const [success, setSuccess]           = useState<EssenceItem[] | null>(null);
+
+  // Inventory of harvested (non-seed) flowers grouped by rarity
+  const sacrificableByRarity = useMemo(() => {
+    const map = new Map<Rarity, typeof state.inventory[number][]>();
+    for (const item of state.inventory) {
+      if (item.isSeed || item.quantity <= 0) continue;
+      const flower = getFlower(item.speciesId);
+      if (!flower) continue;
+      const list = map.get(flower.rarity) ?? [];
+      list.push(item);
+      map.set(flower.rarity, list);
+    }
+    return map;
+  }, [state.inventory]);
+
+  const rarityOrder: Rarity[] = ["common", "uncommon", "rare", "legendary", "mythic", "exalted", "prismatic"];
+
+  const filteredItems = useMemo(() => {
+    if (!activeRarity) return [];
+    return sacrificableByRarity.get(activeRarity) ?? [];
+  }, [activeRarity, sacrificableByRarity]);
+
+  const totalSelected = useMemo(() =>
+    Array.from(selections.values()).reduce((sum, n) => sum + n, 0),
+    [selections]
+  );
+
+  function setQty(speciesId: string, mutation: MutationType | undefined, qty: number) {
+    const key = mapKey(speciesId, mutation);
+    setSelections((prev) => {
+      const next = new Map(prev);
+      if (qty <= 0) next.delete(key);
+      else next.set(key, qty);
+      return next;
+    });
+  }
+
+  function getQty(speciesId: string, mutation: MutationType | undefined): number {
+    return selections.get(mapKey(speciesId, mutation)) ?? 0;
+  }
+
+  function handleSelectAll() {
+    const next = new Map(selections);
+    for (const item of filteredItems) {
+      const available = item.quantity - (next.get(mapKey(item.speciesId, item.mutation)) ?? 0);
+      if (available > 0) {
+        next.set(mapKey(item.speciesId, item.mutation), item.quantity);
+      }
+    }
+    setSelections(next);
+  }
+
+  function handleClearRarity() {
+    const next = new Map(selections);
+    for (const item of filteredItems) {
+      next.delete(mapKey(item.speciesId, item.mutation));
+    }
+    setSelections(next);
+  }
+
+  async function handleSacrifice() {
+    if (sacrificing || totalSelected === 0) return;
+    setSacrificing(true);
+    setError(null);
+    setSuccess(null);
+
+    const sacrifices: SacrificeEntry[] = [];
+    for (const [key, quantity] of selections) {
+      if (quantity <= 0) continue;
+      const { speciesId, mutation } = parseKey(key);
+      sacrifices.push({ speciesId, mutation, quantity });
+    }
+
+    const optimistic = sacrificeFlowers(state, sacrifices);
+    if (!optimistic) {
+      setError("Invalid selection — check your inventory.");
+      setSacrificing(false);
+      return;
+    }
+
+    let succeeded = false;
+
+    await perform(
+      optimistic,
+      () => edgeAlchemySacrifice(
+        sacrifices.map((s) => ({
+          speciesId: s.speciesId,
+          mutation:  s.mutation as string | undefined,
+          quantity:  s.quantity,
+        }))
+      ),
+      (result) => {
+        setSuccess(result.essences);
+        setSelections(new Map());
+        succeeded = true;
+      },
+      // No serialize — sacrifice is standalone (doesn't race with harvest/plant).
+      // Default (non-serialized) perform awaits the server call before returning,
+      // so we can check `succeeded` right after the await.
+    );
+
+    if (!succeeded) {
+      setError("Sacrifice failed — please try again.");
+    }
+
+    setSacrificing(false);
+  }
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col gap-5">
+
+      {/* Tab switcher: Sacrifice | Essences */}
+      <div className="flex rounded-xl border border-border bg-card/40 p-0.5 gap-0.5">
+        {(["sacrifice", "essences"] as AlchemyView[]).map((v) => (
+          <button
+            key={v}
+            onClick={() => setView(v)}
+            className={`
+              flex-1 py-1.5 rounded-[10px] text-xs font-semibold capitalize transition-all duration-150
+              ${view === v
+                ? "bg-card text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+              }
+            `}
+          >
+            {v === "sacrifice" ? "⚗️ Sacrifice" : "✨ Essences"}
+          </button>
+        ))}
+      </div>
+
+      {/* ── ESSENCES view ── */}
+      {view === "essences" && (
+        <div className="flex flex-col gap-4">
+          <div>
+            <p className="text-xs font-semibold mb-0.5">Your Essence Bank</p>
+            <p className="text-[11px] text-muted-foreground">
+              Essences are earned by sacrificing flowers. Use them in the Infuse tab to enhance seeds.
+            </p>
+          </div>
+          <EssenceWallet essences={state.essences ?? []} />
+          <div className="rounded-xl border border-border bg-card/40 px-4 py-3">
+            <p className="text-xs font-semibold mb-2">Essence Yield Table</p>
+            <div className="space-y-1">
+              {rarityOrder.map((rarity) => {
+                const cfg = RARITY_CONFIG[rarity];
+                return (
+                  <div key={rarity} className="flex items-center justify-between text-xs">
+                    <span className={cfg.color}>{cfg.label}</span>
+                    <span className="text-muted-foreground font-mono">
+                      {ESSENCE_YIELD[rarity]} per flower
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── SACRIFICE view ── */}
+      {view === "sacrifice" && (
+        <div className="flex flex-col gap-4">
+
+          {/* Description */}
+          <p className="text-[11px] text-muted-foreground">
+            Sacrifice harvested flowers to extract their elemental essence. Higher rarity yields more essence.
+          </p>
+
+          {/* Success banner */}
+          {success && (
+            <div className="bg-primary/10 border border-primary/40 rounded-xl px-4 py-3 flex flex-col gap-2">
+              <p className="text-xs font-semibold text-primary">Sacrifice complete!</p>
+              <div className="flex flex-wrap gap-1.5">
+                {success.filter((e) => e.amount > 0).map(({ type, amount }) => {
+                  const cfg = FLOWER_TYPES[type];
+                  return (
+                    <span
+                      key={type}
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border text-[11px] font-semibold ${cfg.bgColor} ${cfg.borderColor} ${cfg.color}`}
+                    >
+                      {cfg.emoji} +{amount}
+                    </span>
+                  );
+                })}
+              </div>
+              <button
+                onClick={() => setSuccess(null)}
+                className="text-[10px] text-primary/70 hover:text-primary self-end"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+
+          {/* Error banner */}
+          {error && (
+            <div className="bg-destructive/10 border border-destructive/40 rounded-xl px-3 py-2 text-xs text-destructive">
+              {error}
+            </div>
+          )}
+
+          {/* Rarity filter tabs */}
+          <div>
+            <p className="text-[10px] text-muted-foreground uppercase tracking-widest mb-2">
+              Filter by rarity
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {rarityOrder.map((rarity) => {
+                const cfg     = RARITY_CONFIG[rarity];
+                const hasAny  = (sacrificableByRarity.get(rarity)?.length ?? 0) > 0;
+                const isActive = activeRarity === rarity;
+                return (
+                  <button
+                    key={rarity}
+                    onClick={() => setActiveRarity(isActive ? null : rarity)}
+                    disabled={!hasAny}
+                    className={`
+                      px-2.5 py-1 rounded-full border text-[11px] font-semibold transition-all duration-150
+                      ${isActive
+                        ? `border-current bg-current/10 ${cfg.color}`
+                        : hasAny
+                          ? `border-border text-muted-foreground hover:border-current hover:${cfg.color}`
+                          : "border-border/30 text-muted-foreground/30 cursor-not-allowed"
+                      }
+                    `}
+                  >
+                    {cfg.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Flower grid for selected rarity */}
+          {activeRarity && (
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-semibold">
+                  <span className={RARITY_CONFIG[activeRarity].color}>
+                    {RARITY_CONFIG[activeRarity].label}
+                  </span>
+                  {" "}flowers
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleSelectAll}
+                    className="text-[10px] text-primary hover:text-primary/80 font-semibold"
+                  >
+                    Select all
+                  </button>
+                  <button
+                    onClick={handleClearRarity}
+                    className="text-[10px] text-muted-foreground hover:text-foreground"
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-2">
+                {filteredItems.map((item) => {
+                  const flower  = getFlower(item.speciesId);
+                  if (!flower) return null;
+                  const mut     = item.mutation ? MUTATIONS[item.mutation as MutationType] : null;
+                  const qty     = getQty(item.speciesId, item.mutation as MutationType | undefined);
+                  const avail   = item.quantity;
+                  const isSelected = qty > 0;
+
+                  return (
+                    <div
+                      key={`${item.speciesId}${item.mutation ?? ""}`}
+                      className={`
+                        relative rounded-xl border p-3 transition-all duration-150
+                        ${isSelected
+                          ? "border-primary/60 bg-primary/10"
+                          : "border-border bg-card/60"
+                        }
+                      `}
+                    >
+                      {/* Top row */}
+                      <div className="flex items-center gap-2 mb-2">
+                        <span className="text-xl">{flower.emoji.bloom}</span>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-xs font-medium truncate">
+                            {mut ? <span className={mut.color}>{mut.emoji} </span> : null}
+                            {flower.name}
+                          </p>
+                          <p className="text-[10px] text-muted-foreground">
+                            {avail} available
+                            {isSelected && ` · ${qty} selected`}
+                          </p>
+                        </div>
+                      </div>
+
+                      {/* Type pills */}
+                      <div className="flex flex-wrap gap-1 mb-2">
+                        {flower.types.map((t) => {
+                          const tc = FLOWER_TYPES[t];
+                          return (
+                            <span
+                              key={t}
+                              className={`text-[9px] px-1.5 py-0.5 rounded-full border font-medium ${tc.bgColor} ${tc.borderColor} ${tc.color}`}
+                            >
+                              {tc.emoji} {tc.name}
+                            </span>
+                          );
+                        })}
+                      </div>
+
+                      {/* Controls */}
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => setQty(item.speciesId, item.mutation as MutationType | undefined, qty - 1)}
+                          disabled={qty <= 0}
+                          className="w-6 h-6 rounded-md border border-border text-muted-foreground text-xs flex items-center justify-center hover:border-primary/50 hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                        >
+                          −
+                        </button>
+                        <span className="flex-1 text-center text-xs font-mono text-muted-foreground">
+                          {qty}
+                        </span>
+                        <button
+                          onClick={() => setQty(item.speciesId, item.mutation as MutationType | undefined, Math.min(qty + 1, avail))}
+                          disabled={qty >= avail}
+                          className="w-6 h-6 rounded-md border border-border text-muted-foreground text-xs flex items-center justify-center hover:border-primary/50 hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                        >
+                          +
+                        </button>
+                        <button
+                          onClick={() => setQty(item.speciesId, item.mutation as MutationType | undefined, avail)}
+                          disabled={qty >= avail}
+                          className="ml-1 text-[9px] text-primary font-semibold disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          Max
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* No rarity selected nudge */}
+          {!activeRarity && totalSelected === 0 && (
+            <div className="text-center py-6 text-xs text-muted-foreground space-y-1">
+              <p className="text-2xl">⚗️</p>
+              <p>Select a rarity above to choose flowers to sacrifice.</p>
+            </div>
+          )}
+
+          {/* Preview */}
+          <SacrificePreview selections={selections} />
+
+          {/* Summary + Sacrifice button */}
+          {totalSelected > 0 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-center text-xs text-muted-foreground">
+                {totalSelected} flower{totalSelected !== 1 ? "s" : ""} selected
+              </p>
+              <button
+                onClick={handleSacrifice}
+                disabled={sacrificing}
+                className={`
+                  w-full py-3 rounded-full text-sm font-semibold border transition-all duration-200
+                  ${sacrificing
+                    ? "border-border text-muted-foreground opacity-50 cursor-not-allowed"
+                    : "border-destructive/60 text-destructive hover:bg-destructive/10 hover:scale-[1.02]"
+                  }
+                `}
+              >
+                {sacrificing ? "Sacrificing…" : `Sacrifice ${totalSelected} flower${totalSelected !== 1 ? "s" : ""}`}
+              </button>
+            </div>
+          )}
+
+          {/* Current essence wallet preview */}
+          {(state.essences ?? []).length > 0 && (
+            <div className="pt-2 border-t border-border">
+              <p className="text-[10px] text-muted-foreground uppercase tracking-widest mb-2">
+                Current essences
+              </p>
+              <EssenceWallet essences={state.essences ?? []} />
+            </div>
+          )}
+
+        </div>
+      )}
+
+    </div>
+  );
+}

--- a/src/components/Botany.tsx
+++ b/src/components/Botany.tsx
@@ -425,7 +425,7 @@ export function Botany() {
         <button
           onClick={() => setTab("convert")}
           className={`
-            flex-1 py-1.5 rounded-[10px] text-xs font-semibold transition-all duration-150
+            flex-1 py-1.5 rounded-[10px] text-xs font-semibold text-center transition-all duration-150
             ${activeTab === "convert"
               ? "bg-card text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground"
@@ -437,7 +437,7 @@ export function Botany() {
         <button
           onClick={() => setTab("alchemy")}
           className={`
-            flex-1 py-1.5 rounded-[10px] text-xs font-semibold transition-all duration-150
+            flex-1 py-1.5 rounded-[10px] text-xs font-semibold text-center transition-all duration-150
             ${activeTab === "alchemy"
               ? "bg-card text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground"

--- a/src/components/Botany.tsx
+++ b/src/components/Botany.tsx
@@ -7,6 +7,9 @@ import { botanyConvert, botanyConvertAll } from "../store/gameStore";
 import { edgeBotanyConvert, edgeBotanyConvertAll } from "../lib/edgeFunctions";
 import type { InventoryItem } from "../store/gameStore";
 import type { Rarity } from "../data/flowers";
+import { AlchemyTab } from "./AlchemyTab";
+
+type BotanyTab = "convert" | "alchemy";
 
 type Selection = { speciesId: string; mutation?: MutationType };
 
@@ -269,6 +272,10 @@ function SelectionScreen({
 export function Botany() {
   const { state, perform } = useGame();
 
+  const [activeTab, setActiveTab] = useState<BotanyTab>(() =>
+    (localStorage.getItem("botany_tab") as BotanyTab | null) ?? "convert"
+  );
+
   const [activeRarity, setActiveRarity]         = useState<Rarity | null>(null);
   const [resultSpeciesId, setResultSpeciesId]   = useState<string | null>(null);
   const [convertAllResult, setConvertAllResult] = useState<string[] | null>(null);
@@ -279,6 +286,11 @@ export function Botany() {
   // Guards against re-entrant auto-convert runs and rollback-triggered retry loops
   const autoConvertRunning  = useRef(false);
   const autoConvertCooldown = useRef(false);
+
+  function setTab(tab: BotanyTab) {
+    localStorage.setItem("botany_tab", tab);
+    setActiveTab(tab);
+  }
 
   function toggleAutoConvert() {
     setAutoConvert((v) => {
@@ -404,10 +416,43 @@ export function Botany() {
       <div className="text-center space-y-1">
         <h2 className="font-bold text-lg tracking-wide">🌿 Botany Lab</h2>
         <p className="text-xs text-muted-foreground max-w-xs mx-auto">
-          Combine harvested flowers to receive a rare seed of the next rarity.
-          Undiscovered species are prioritised.
+          Convert flowers to rarer seeds, or sacrifice them for elemental essence.
         </p>
       </div>
+
+      {/* Tab switcher */}
+      <div className="flex rounded-xl border border-border bg-card/40 p-0.5 gap-0.5">
+        <button
+          onClick={() => setTab("convert")}
+          className={`
+            flex-1 py-1.5 rounded-[10px] text-xs font-semibold transition-all duration-150
+            ${activeTab === "convert"
+              ? "bg-card text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+            }
+          `}
+        >
+          🔄 Convert
+        </button>
+        <button
+          onClick={() => setTab("alchemy")}
+          className={`
+            flex-1 py-1.5 rounded-[10px] text-xs font-semibold transition-all duration-150
+            ${activeTab === "alchemy"
+              ? "bg-card text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+            }
+          `}
+        >
+          ⚗️ Alchemy
+        </button>
+      </div>
+
+      {/* Alchemy tab */}
+      {activeTab === "alchemy" && <AlchemyTab />}
+
+      {/* Convert tab content below — hidden when alchemy is active */}
+      {activeTab === "convert" && (<>
 
       {/* Auto-convert toggle */}
       <div className="flex items-center justify-between bg-card/60 border border-border rounded-xl px-4 py-3">
@@ -531,6 +576,8 @@ export function Botany() {
       <p className="text-center text-[10px] text-muted-foreground">
         Harvest flowers from your garden to fill the conversion stations.
       </p>
+      </>)}
+
     </div>
   );
 }

--- a/src/data/essences.ts
+++ b/src/data/essences.ts
@@ -1,0 +1,78 @@
+import type { FlowerType } from "./flowers";
+import type { Rarity } from "./flowers";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type EssenceType = FlowerType;
+
+export interface EssenceItem {
+  type: EssenceType;
+  amount: number;
+}
+
+// ── Yield table ────────────────────────────────────────────────────────────
+
+/**
+ * How many essence units a single flower of each rarity produces when sacrificed.
+ * Units are then distributed among the flower's type(s) via independent rolls.
+ */
+export const ESSENCE_YIELD: Record<Rarity, number> = {
+  common:    1,
+  uncommon:  2,
+  rare:      4,
+  legendary: 8,
+  mythic:    16,
+  exalted:   32,
+  prismatic: 64,
+};
+
+// ── Yield calculation (deterministic even-split for UI preview) ────────────
+
+/**
+ * Returns the expected essence yield for a batch sacrifice.
+ * Uses a deterministic even split across the flower's types so the UI preview
+ * is stable.  The edge function uses the same even-split for simplicity/fairness
+ * (no hidden randomness on essence distribution).
+ *
+ * @param types   - The flower's type list (1–N items)
+ * @param rarity  - The flower's rarity tier
+ * @param quantity - Number of flowers being sacrificed
+ */
+export function calculateEssenceYield(
+  types: EssenceType[],
+  rarity: Rarity,
+  quantity: number,
+): EssenceItem[] {
+  if (types.length === 0 || quantity === 0) return [];
+
+  const yieldPer = ESSENCE_YIELD[rarity];
+  const total    = yieldPer * quantity;
+
+  // Even-split: spread total units across types as evenly as possible.
+  // Remainder units go to the first N types.
+  const perType   = Math.floor(total / types.length);
+  const remainder = total % types.length;
+
+  return types
+    .map((type, i) => ({ type, amount: perType + (i < remainder ? 1 : 0) }))
+    .filter((e) => e.amount > 0);
+}
+
+/**
+ * Merges a list of new essence yields into an existing essences array.
+ * Used both client-side (optimistic) and in utility tests.
+ */
+export function mergeEssences(
+  current: EssenceItem[],
+  additions: EssenceItem[],
+): EssenceItem[] {
+  const map = new Map<EssenceType, number>(
+    current.map((e) => [e.type, e.amount])
+  );
+  for (const { type, amount } of additions) {
+    map.set(type, (map.get(type) ?? 0) + amount);
+  }
+  return Array.from(map.entries())
+    .map(([type, amount]) => ({ type, amount }))
+    .filter((e) => e.amount > 0);
+}

--- a/src/lib/edgeFunctions.ts
+++ b/src/lib/edgeFunctions.ts
@@ -319,3 +319,17 @@ export function edgeMarketplaceCancel(listingId: string) {
 export function edgeClaimMail(mailId: string) {
   return callEdge<ClaimMailResult>("claim-mail", { mailId });
 }
+
+// ── Alchemy ───────────────────────────────────────────────────────────────────
+
+export interface AlchemySacrificeResult {
+  ok:        true;
+  inventory: GameState["inventory"];
+  essences:  GameState["essences"];
+}
+
+export function edgeAlchemySacrifice(
+  sacrifices: { speciesId: string; mutation?: string; quantity: number }[]
+) {
+  return callEdge<AlchemySacrificeResult>("alchemy-sacrifice", { sacrifices });
+}

--- a/src/store/cloudSave.ts
+++ b/src/store/cloudSave.ts
@@ -137,6 +137,8 @@ export async function loadCloudSave(userId: string): Promise<GameState | null> {
       supplyShop:           (data.supply_shop     as GameState["supplyShop"])     ?? [],
       supplySlots:          (data.supply_slots    as number)                      ?? 2,
       lastSupplyReset:      (data.last_supply_reset as number)                    ?? 0,
+      // Alchemy & Botany
+      essences:             (data.essences        as GameState["essences"])       ?? [],
     } as GameState;
   } catch {
     return null;
@@ -168,6 +170,8 @@ export async function saveToCloud(
       supply_shop:            state.supplyShop        ?? [],
       supply_slots:           state.supplySlots       ?? 2,
       last_supply_reset:      state.lastSupplyReset   ?? 0,
+      // Alchemy & Botany
+      essences:               state.essences          ?? [],
       updated_at:             new Date().toISOString(),
     });
 
@@ -233,6 +237,7 @@ export async function getPublicSave(userId: string): Promise<GameState | null> {
     supplyShop:           (data.supply_shop     as GameState["supplyShop"])     ?? [],
     supplySlots:          (data.supply_slots    as number)                      ?? 2,
     lastSupplyReset:      (data.last_supply_reset as number)                    ?? 0,
+    essences:             (data.essences        as GameState["essences"])       ?? [],
   } as GameState;
 }
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -3,6 +3,7 @@ import { FERTILIZERS, getNextUpgrade, getNextShopSlotUpgrade, getNextMarketplace
 import type { WeatherType } from "../data/weather";
 import { WEATHER } from "../data/weather";
 import { BOTANY_REQUIREMENTS, NEXT_RARITY } from "../data/botany";
+import { mergeEssences, calculateEssenceYield, type EssenceItem } from "../data/essences";
 import {
   WEATHER_MUT_CHANCE_PER_TICK,
   THUNDERSTORM_WET_CHANCE_PER_TICK,
@@ -59,6 +60,8 @@ export interface FertilizerItem {
   quantity: number;
 }
 
+export type { EssenceItem };
+
 export interface ShopSlot {
   speciesId:     string;
   price:         number;
@@ -94,6 +97,8 @@ export interface GameState {
   supplyShop:       ShopSlot[];
   lastSupplyReset:  number;
   gearInventory:    GearInventoryItem[];
+  // Alchemy — essence tokens per flower type
+  essences:         EssenceItem[];
 }
 
 export interface OfflineSummary {
@@ -346,6 +351,7 @@ export function defaultState(): GameState {
     supplyShop:           generateSupplyShop(DEFAULT_SUPPLY_SLOTS),
     lastSupplyReset:      now,
     gearInventory:        [],
+    essences:             [],
   };
 }
 
@@ -424,6 +430,7 @@ export function applyOfflineTick(
     supplyShop:           save.supplyShop           ?? generateSupplyShop(save.supplySlots ?? DEFAULT_SUPPLY_SLOTS),
     lastSupplyReset:      save.lastSupplyReset       ?? now2,
     gearInventory:        save.gearInventory         ?? [],
+    essences:             save.essences              ?? [],
   };
 
   let shopRestocked    = false;
@@ -2025,6 +2032,59 @@ export function upgradeSupplySlots(state: GameState): GameState | null {
     supplySlots: next.slots,
     supplyShop:  [...(state.supplyShop ?? []), ...emptySlots],
   };
+}
+
+// ── Alchemy — sacrifice ────────────────────────────────────────────────────
+
+export interface SacrificeEntry {
+  speciesId: string;
+  mutation?: MutationType;
+  quantity: number;
+}
+
+/**
+ * Optimistically consumes flowers and adds essences.
+ * The edge function mirrors this logic server-side.
+ * Returns null if any sacrifice entry is invalid (wrong species / not enough stock).
+ */
+export function sacrificeFlowers(
+  state: GameState,
+  sacrifices: SacrificeEntry[],
+): GameState | null {
+  if (sacrifices.length === 0) return null;
+
+  // Validate every entry first
+  for (const { speciesId, mutation, quantity } of sacrifices) {
+    if (quantity < 1) return null;
+    const species = getFlower(speciesId);
+    if (!species) return null;
+    const invItem = state.inventory.find(
+      (i) => i.speciesId === speciesId && i.mutation === mutation && !i.isSeed
+    );
+    if (!invItem || invItem.quantity < quantity) return null;
+  }
+
+  // Consume flowers
+  let newInventory = [...state.inventory];
+  for (const { speciesId, mutation, quantity } of sacrifices) {
+    newInventory = newInventory
+      .map((i) =>
+        i.speciesId === speciesId && i.mutation === mutation && !i.isSeed
+          ? { ...i, quantity: i.quantity - quantity }
+          : i
+      )
+      .filter((i) => i.quantity > 0);
+  }
+
+  // Accumulate essence deltas
+  let newEssences = [...state.essences];
+  for (const { speciesId, mutation: _mut, quantity } of sacrifices) {
+    const species = getFlower(speciesId)!;
+    const yields  = calculateEssenceYield(species.types, species.rarity, quantity);
+    newEssences   = mergeEssences(newEssences, yields);
+  }
+
+  return { ...state, inventory: newInventory, essences: newEssences };
 }
 
 export function upgradeFarm(state: GameState): GameState | null {

--- a/supabase/functions/alchemy-sacrifice/index.ts
+++ b/supabase/functions/alchemy-sacrifice/index.ts
@@ -1,0 +1,347 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin":  "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+// base64url → base64 with proper padding for Deno's strict atob()
+function b64url(s: string): string {
+  const t = s.replace(/-/g, "+").replace(/_/g, "/");
+  return t + "=".repeat((4 - t.length % 4) % 4);
+}
+
+// ── Flower catalogue (id → rarity + types) ────────────────────────────────
+
+type Rarity = "common" | "uncommon" | "rare" | "legendary" | "mythic" | "exalted" | "prismatic";
+type FlowerType = "blaze" | "tide" | "grove" | "frost" | "storm" | "lunar" | "solar" | "fairy" | "shadow" | "arcane" | "stellar" | "zephyr";
+
+const FLOWERS: { id: string; rarity: Rarity; types: FlowerType[] }[] = [
+  // COMMON
+  { id: "quickgrass",   rarity: "common",   types: ["grove"] },
+  { id: "dustweed",     rarity: "common",   types: ["zephyr", "shadow"] },
+  { id: "sprig",        rarity: "common",   types: ["grove"] },
+  { id: "dewdrop",      rarity: "common",   types: ["tide"] },
+  { id: "pebblebloom",  rarity: "common",   types: ["grove"] },
+  { id: "ember_moss",   rarity: "common",   types: ["blaze", "grove"] },
+  { id: "dandelion",    rarity: "common",   types: ["grove", "zephyr"] },
+  { id: "clover",       rarity: "common",   types: ["grove", "fairy"] },
+  { id: "violet",       rarity: "common",   types: ["fairy", "arcane"] },
+  { id: "lemongrass",   rarity: "common",   types: ["grove", "solar"] },
+  { id: "daisy",        rarity: "common",   types: ["grove", "fairy"] },
+  { id: "honeywort",    rarity: "common",   types: ["grove", "solar"] },
+  { id: "buttercup",    rarity: "common",   types: ["fairy", "solar"] },
+  { id: "dawnpetal",    rarity: "common",   types: ["lunar", "solar"] },
+  { id: "poppy",        rarity: "common",   types: ["blaze", "grove"] },
+  { id: "chamomile",    rarity: "common",   types: ["grove", "solar"] },
+  { id: "marigold",     rarity: "common",   types: ["solar", "grove"] },
+  { id: "sunflower",    rarity: "common",   types: ["solar"] },
+  { id: "coppercup",    rarity: "common",   types: ["grove"] },
+  { id: "ivybell",      rarity: "common",   types: ["grove", "tide"] },
+  { id: "thornberry",   rarity: "common",   types: ["grove"] },
+  { id: "saltmoss",     rarity: "common",   types: ["tide"] },
+  { id: "ashpetal",     rarity: "common",   types: ["shadow", "zephyr"] },
+  { id: "snowdrift",    rarity: "common",   types: ["frost"] },
+  // UNCOMMON
+  { id: "swiftbloom",     rarity: "uncommon", types: ["zephyr"] },
+  { id: "shortcress",     rarity: "uncommon", types: ["grove"] },
+  { id: "thornwhistle",   rarity: "uncommon", types: ["grove", "blaze"] },
+  { id: "starwort",       rarity: "uncommon", types: ["stellar"] },
+  { id: "mintleaf",       rarity: "uncommon", types: ["grove", "frost"] },
+  { id: "tulip",          rarity: "uncommon", types: ["fairy", "grove"] },
+  { id: "inkbloom",       rarity: "uncommon", types: ["arcane", "shadow"] },
+  { id: "hyacinth",       rarity: "uncommon", types: ["blaze", "fairy"] },
+  { id: "snapdragon",     rarity: "uncommon", types: ["blaze", "arcane"] },
+  { id: "beebalm",        rarity: "uncommon", types: ["grove", "solar"] },
+  { id: "candleflower",   rarity: "uncommon", types: ["blaze", "arcane"] },
+  { id: "carnation",      rarity: "uncommon", types: ["fairy"] },
+  { id: "ribbonweed",     rarity: "uncommon", types: ["fairy"] },
+  { id: "hibiscus",       rarity: "uncommon", types: ["solar", "blaze"] },
+  { id: "wildberry",      rarity: "uncommon", types: ["grove"] },
+  { id: "frostbell",      rarity: "uncommon", types: ["frost"] },
+  { id: "bluebell",       rarity: "uncommon", types: ["fairy", "tide"] },
+  { id: "cherry_blossom", rarity: "uncommon", types: ["fairy", "grove"] },
+  { id: "rose",           rarity: "uncommon", types: ["fairy"] },
+  { id: "peacockflower",  rarity: "uncommon", types: ["arcane", "zephyr"] },
+  { id: "bamboo_bloom",   rarity: "uncommon", types: ["grove", "zephyr"] },
+  { id: "hummingbloom",   rarity: "uncommon", types: ["zephyr", "fairy"] },
+  { id: "water_lily",     rarity: "uncommon", types: ["tide"] },
+  { id: "lanternflower",  rarity: "uncommon", types: ["blaze", "arcane"] },
+  { id: "dovebloom",      rarity: "uncommon", types: ["zephyr", "fairy"] },
+  { id: "coral_bells",    rarity: "uncommon", types: ["tide", "fairy"] },
+  { id: "sundew",         rarity: "uncommon", types: ["grove", "shadow"] },
+  { id: "bubblebloom",    rarity: "uncommon", types: ["tide", "fairy"] },
+  // RARE
+  { id: "flashpetal",        rarity: "rare", types: ["storm"] },
+  { id: "rushwillow",        rarity: "rare", types: ["zephyr", "tide"] },
+  { id: "sweetheart_lily",   rarity: "rare", types: ["fairy"] },
+  { id: "glassbell",         rarity: "rare", types: ["arcane", "stellar"] },
+  { id: "stormcaller",       rarity: "rare", types: ["storm"] },
+  { id: "lavender",          rarity: "rare", types: ["fairy", "arcane"] },
+  { id: "amber_crown",       rarity: "rare", types: ["solar", "blaze"] },
+  { id: "peach_blossom",     rarity: "rare", types: ["grove", "fairy"] },
+  { id: "foxglove",          rarity: "rare", types: ["shadow", "arcane"] },
+  { id: "butterbloom",       rarity: "rare", types: ["fairy", "zephyr"] },
+  { id: "peony",             rarity: "rare", types: ["fairy"] },
+  { id: "tidebloom",         rarity: "rare", types: ["tide"] },
+  { id: "starweave",         rarity: "rare", types: ["stellar", "arcane"] },
+  { id: "wisteria",          rarity: "rare", types: ["fairy", "arcane"] },
+  { id: "dreamcup",          rarity: "rare", types: ["fairy", "arcane"] },
+  { id: "coralbell",         rarity: "rare", types: ["tide"] },
+  { id: "foxfire",           rarity: "rare", types: ["blaze", "arcane"] },
+  { id: "bird_of_paradise",  rarity: "rare", types: ["zephyr", "solar"] },
+  { id: "solarbell",         rarity: "rare", types: ["solar"] },
+  { id: "moonpetal",         rarity: "rare", types: ["lunar"] },
+  { id: "orchid",            rarity: "rare", types: ["fairy", "arcane"] },
+  { id: "duskrose",          rarity: "rare", types: ["lunar", "shadow"] },
+  { id: "passionflower",     rarity: "rare", types: ["arcane", "storm"] },
+  { id: "glasswing",         rarity: "rare", types: ["arcane"] },
+  { id: "mirror_orchid",     rarity: "rare", types: ["arcane", "stellar"] },
+  { id: "stargazer_lily",    rarity: "rare", types: ["stellar"] },
+  { id: "prism_lily",        rarity: "rare", types: ["arcane", "stellar"] },
+  { id: "dusk_orchid",       rarity: "rare", types: ["lunar", "solar"] },
+  // LEGENDARY
+  { id: "firstbloom",       rarity: "legendary", types: ["solar", "fairy"] },
+  { id: "haste_lily",       rarity: "legendary", types: ["zephyr", "storm"] },
+  { id: "verdant_crown",    rarity: "legendary", types: ["grove", "fairy"] },
+  { id: "ironwood_bloom",   rarity: "legendary", types: ["grove"] },
+  { id: "sundial",          rarity: "legendary", types: ["solar", "arcane"] },
+  { id: "lotus",            rarity: "legendary", types: ["tide", "arcane"] },
+  { id: "candy_blossom",    rarity: "legendary", types: ["fairy"] },
+  { id: "prismbark",        rarity: "legendary", types: ["grove", "arcane"] },
+  { id: "dolphinia",        rarity: "legendary", types: ["tide"] },
+  { id: "ghost_orchid",     rarity: "legendary", types: ["shadow", "arcane"] },
+  { id: "nestbloom",        rarity: "legendary", types: ["grove", "fairy"] },
+  { id: "black_rose",       rarity: "legendary", types: ["shadow"] },
+  { id: "pumpkin_blossom",  rarity: "legendary", types: ["shadow", "grove"] },
+  { id: "starburst_lily",   rarity: "legendary", types: ["stellar", "storm"] },
+  { id: "sporebloom",       rarity: "legendary", types: ["grove", "shadow"] },
+  { id: "fire_lily",        rarity: "legendary", types: ["blaze"] },
+  { id: "stargazer",        rarity: "legendary", types: ["stellar"] },
+  { id: "fullmoon_bloom",   rarity: "legendary", types: ["lunar"] },
+  { id: "ice_crown",        rarity: "legendary", types: ["frost"] },
+  { id: "diamond_bloom",    rarity: "legendary", types: ["frost", "arcane"] },
+  { id: "oracle_eye",       rarity: "legendary", types: ["arcane", "shadow"] },
+  { id: "halfmoon_bloom",   rarity: "legendary", types: ["lunar"] },
+  { id: "aurora_bloom",     rarity: "legendary", types: ["stellar", "arcane"] },
+  { id: "mirrorpetal",      rarity: "legendary", types: ["arcane", "stellar"] },
+  { id: "emberspark",       rarity: "legendary", types: ["blaze", "storm"] },
+  // MYTHIC
+  { id: "blink_rose",      rarity: "mythic", types: ["arcane", "shadow"] },
+  { id: "dawnfire",        rarity: "mythic", types: ["solar", "blaze"] },
+  { id: "moonflower",      rarity: "mythic", types: ["lunar"] },
+  { id: "jellybloom",      rarity: "mythic", types: ["tide", "arcane"] },
+  { id: "celestial_bloom", rarity: "mythic", types: ["stellar"] },
+  { id: "void_blossom",    rarity: "mythic", types: ["shadow", "arcane"] },
+  { id: "seraph_wing",     rarity: "mythic", types: ["zephyr", "fairy"] },
+  { id: "solar_rose",      rarity: "mythic", types: ["solar"] },
+  { id: "nebula_drift",    rarity: "mythic", types: ["stellar", "arcane"] },
+  { id: "superbloom",      rarity: "mythic", types: ["storm", "stellar"] },
+  { id: "wanderbloom",     rarity: "mythic", types: ["zephyr", "arcane"] },
+  { id: "chrysanthemum",   rarity: "mythic", types: ["arcane", "stellar", "fairy"] },
+  // EXALTED
+  { id: "umbral_bloom",   rarity: "exalted", types: ["shadow", "lunar"] },
+  { id: "obsidian_rose",  rarity: "exalted", types: ["shadow"] },
+  { id: "duskmantle",     rarity: "exalted", types: ["shadow", "lunar"] },
+  { id: "graveweb",       rarity: "exalted", types: ["shadow"] },
+  { id: "nightwing",      rarity: "exalted", types: ["shadow", "zephyr"] },
+  { id: "ashenveil",      rarity: "exalted", types: ["shadow", "blaze"] },
+  { id: "voidfire",       rarity: "exalted", types: ["shadow", "blaze"] },
+  // PRISMATIC
+  { id: "dreambloom",        rarity: "prismatic", types: ["fairy", "arcane"] },
+  { id: "fairy_blossom",     rarity: "prismatic", types: ["fairy"] },
+  { id: "lovebind",          rarity: "prismatic", types: ["fairy", "arcane"] },
+  { id: "eternal_heart",     rarity: "prismatic", types: ["fairy", "solar"] },
+  { id: "nova_bloom",        rarity: "prismatic", types: ["stellar", "storm", "blaze"] },
+  { id: "princess_blossom",  rarity: "prismatic", types: ["fairy", "arcane"] },
+];
+
+const FLOWER_MAP = new Map(FLOWERS.map((f) => [f.id, f]));
+
+// ── Essence yield table ────────────────────────────────────────────────────
+
+const ESSENCE_YIELD: Record<Rarity, number> = {
+  common:    1,
+  uncommon:  2,
+  rare:      4,
+  legendary: 8,
+  mythic:    16,
+  exalted:   32,
+  prismatic: 64,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+interface EssenceItem { type: FlowerType; amount: number; }
+interface InventoryItem { speciesId: string; quantity: number; mutation?: string; isSeed?: boolean; }
+
+/**
+ * Deterministic even-split — same algorithm as calculateEssenceYield() on the client.
+ * The preview and the actual result will always match.
+ */
+function calculateYield(types: FlowerType[], rarity: Rarity, quantity: number): EssenceItem[] {
+  if (types.length === 0 || quantity === 0) return [];
+  const total   = ESSENCE_YIELD[rarity] * quantity;
+  const perType = Math.floor(total / types.length);
+  const rem     = total % types.length;
+  return types
+    .map((type, i) => ({ type, amount: perType + (i < rem ? 1 : 0) }))
+    .filter((e) => e.amount > 0);
+}
+
+function mergeEssences(current: EssenceItem[], additions: EssenceItem[]): EssenceItem[] {
+  const map = new Map<FlowerType, number>(current.map((e) => [e.type, e.amount]));
+  for (const { type, amount } of additions) {
+    map.set(type, (map.get(type) ?? 0) + amount);
+  }
+  return Array.from(map.entries())
+    .map(([type, amount]) => ({ type, amount }))
+    .filter((e) => e.amount > 0);
+}
+
+// ── Handler ────────────────────────────────────────────────────────────────
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const token = authHeader.replace("Bearer ", "");
+
+    // Decode userId from JWT payload without full verification (parallel load)
+    let userId: string;
+    try {
+      const p = JSON.parse(atob(b64url(token.split(".")[1])));
+      userId = p.sub;
+    } catch {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+    );
+
+    // ── Parse input ───────────────────────────────────────────────────────────
+    const { sacrifices } = await req.json() as {
+      sacrifices: { speciesId: string; mutation?: string; quantity: number }[];
+    };
+
+    if (!Array.isArray(sacrifices) || sacrifices.length === 0) {
+      return new Response(JSON.stringify({ error: "sacrifices array is required" }), {
+        status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // ── Verify JWT + load save in parallel ────────────────────────────────────
+    const [authResult, saveResult] = await Promise.all([
+      supabaseAdmin.auth.getUser(token),
+      supabaseAdmin
+        .from("game_saves")
+        .select("inventory, essences, updated_at")
+        .eq("user_id", userId)
+        .single(),
+    ]);
+
+    if (authResult.error || !authResult.data.user || authResult.data.user.id !== userId) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    if (saveResult.error || !saveResult.data) {
+      return new Response(JSON.stringify({ error: "Save not found" }), {
+        status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const save = saveResult.data;
+    const priorUpdatedAt = save.updated_at as string;
+
+    let inventory = (save.inventory ?? []) as InventoryItem[];
+    let essences  = (save.essences  ?? []) as EssenceItem[];
+
+    // ── Validate each sacrifice entry ─────────────────────────────────────────
+    for (const { speciesId, mutation, quantity } of sacrifices) {
+      if (!Number.isInteger(quantity) || quantity < 1) {
+        return new Response(JSON.stringify({ error: `Invalid quantity for ${speciesId}` }), {
+          status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+      const flower = FLOWER_MAP.get(speciesId);
+      if (!flower) {
+        return new Response(JSON.stringify({ error: `Unknown species: ${speciesId}` }), {
+          status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+      const invItem = inventory.find(
+        (i) => i.speciesId === speciesId && i.mutation === (mutation ?? undefined) && !i.isSeed
+      );
+      if (!invItem || invItem.quantity < quantity) {
+        return new Response(JSON.stringify({ error: `Insufficient inventory for ${speciesId}` }), {
+          status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    // ── Apply sacrifices ──────────────────────────────────────────────────────
+    for (const { speciesId, mutation, quantity } of sacrifices) {
+      const flower = FLOWER_MAP.get(speciesId)!;
+
+      // Consume flowers from inventory
+      inventory = inventory
+        .map((i) =>
+          i.speciesId === speciesId && i.mutation === (mutation ?? undefined) && !i.isSeed
+            ? { ...i, quantity: i.quantity - quantity }
+            : i
+        )
+        .filter((i) => i.quantity > 0);
+
+      // Calculate and merge essence yield
+      const yields = calculateYield(flower.types, flower.rarity, quantity);
+      essences     = mergeEssences(essences, yields);
+    }
+
+    // ── Write to DB (optimistic-concurrency guard on updated_at) ─────────────
+    const { data: updateData, error: updateError } = await supabaseAdmin
+      .from("game_saves")
+      .update({ inventory, essences, updated_at: new Date().toISOString() })
+      .eq("user_id", userId)
+      .eq("updated_at", priorUpdatedAt)
+      .select("updated_at")
+      .single();
+
+    if (updateError || !updateData) {
+      return new Response(JSON.stringify({ error: "Save was modified by another action" }), {
+        status: 409, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    void supabaseAdmin.from("action_log").insert({
+      user_id: userId,
+      action:  "alchemy_sacrifice",
+      payload: { sacrifices },
+      result:  { essencesAdded: essences },
+    });
+
+    return new Response(
+      JSON.stringify({ ok: true, inventory, essences }),
+      { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("alchemy-sacrifice error:", err);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/migrations/20260428000005_essences_column.sql
+++ b/supabase/migrations/20260428000005_essences_column.sql
@@ -1,0 +1,3 @@
+-- Add essences column to game_saves for the Alchemy system (v2.3.0 #117)
+ALTER TABLE game_saves
+  ADD COLUMN IF NOT EXISTS essences jsonb NOT NULL DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Summary
- Adds the **Alchemy** tab to the Botany Lab alongside the existing Convert tab
- Players can sacrifice harvested flowers to extract elemental **essence** (12 types, one per flower type)
- Essence yield scales with rarity: Common = 1 → Prismatic = 64 per flower
- Multi-type flowers split their yield evenly across types (deterministic, no hidden RNG — preview always matches result)

## Test plan
- [ ] Sacrifice a single common flower — confirm 1 essence of the correct type is added
- [ ] Sacrifice a multi-type flower (e.g. Daisy: grove + fairy) — confirm yield splits evenly
- [ ] Sacrifice more than available inventory — confirm the button is disabled / server rejects it
- [ ] Switch between Convert and Alchemy tabs — confirm tab choice persists on reload
- [ ] Confirm essences survive a cloud save → reload cycle
- [ ] Verify the DB migration (`essences` column) applied cleanly on Supabase
