### PR TITLE
potential fix for issue 126

### DIFF
--- a/supabase/functions/harvest/index.ts
+++ b/supabase/functions/harvest/index.ts
@@ -175,7 +175,7 @@ Deno.serve(async (req: Request) => {
       supabaseAdmin.auth.getUser(token),
       supabaseAdmin.from("game_saves").select("coins, grid, inventory, discovered, updated_at").eq("user_id", userId).single(),
       // plant_timings has no client write policy — planted_at cannot be forged
-      supabaseAdmin.from("plant_timings").select("planted_at").eq("user_id", userId).eq("row", row).eq("col", col).maybeSingle(),
+      supabaseAdmin.from("plant_timings").select("planted_at, species_id").eq("user_id", userId).eq("row", row).eq("col", col).maybeSingle(),
     ]);
 
     if (authResult.error || !authResult.data.user || authResult.data.user.id !== userId) {
@@ -235,14 +235,38 @@ Deno.serve(async (req: Request) => {
     const fertMultiplier = plant.fertilizer ? (FERTILIZER_MULTIPLIERS[plant.fertilizer] ?? 1.0) : 1.0;
     const masteredBonus  = plant.masteredBonus ?? 1.0;
 
-    // Use server-authoritative planted_at from plant_timings when available.
-    // Falls back to timePlanted for plants that predate this fix — those remain
-    // vulnerable until they are harvested and replanted, at which point plant-seed
-    // will create a plant_timings entry for them.
-    const authoritativePlantedAt = timingResult?.data?.planted_at
-      ? new Date(timingResult.data.planted_at).getTime()
-      : plant.timePlanted;
+    // Server-authoritative planted_at. NEVER fall back to plant.timePlanted —
+    // that field lives in game_saves.grid (client-writable via the REST API
+    // used by saveToCloud), so trusting it lets a user PATCH the grid blob to
+    // backdate timePlanted and harvest instantly. See migration
+    // 20260428000004_plant_timings.sql for the full threat model.
+    //
+    // If no row exists (legacy plant from before plant_timings shipped, or a
+    // plant whose timing insert failed), lazily register the plant as if it
+    // had just been planted now and reject this harvest. The plant will grow
+    // legitimately from this point forward. Also reject if the recorded
+    // species does not match the grid — indicates the plot was rebuilt
+    // without going through plant-seed.
+    const timing = timingResult?.data;
+    if (!timing || timing.species_id !== plant.speciesId) {
+      const insertRes = await supabaseAdmin
+        .from("plant_timings")
+        .upsert(
+          { user_id: userId, row, col, species_id: plant.speciesId, planted_at: new Date().toISOString() },
+          { onConflict: "user_id,row,col" }
+        );
+      if (insertRes.error) {
+        console.error("plant_timings backfill failed:", insertRes.error);
+        return new Response(JSON.stringify({ error: "Internal server error" }), {
+          status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ error: "Plant is not ready to harvest" }), {
+        status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
 
+    const authoritativePlantedAt = new Date(timing.planted_at).getTime();
     const minBloomTime = authoritativePlantedAt + totalGrowthMs / (fertMultiplier * masteredBonus * MAX_WEATHER_MULTIPLIER);
 
     if (Date.now() < minBloomTime) {

--- a/supabase/functions/plant-seed/index.ts
+++ b/supabase/functions/plant-seed/index.ts
@@ -136,6 +136,28 @@ Deno.serve(async (req: Request) => {
       .map((i) => i.speciesId === speciesId && i.isSeed ? { ...i, quantity: i.quantity - 1 } : i)
       .filter((i) => i.quantity > 0);
 
+    // ── Record server-authoritative planting time BEFORE the grid update ────
+    // plant_timings has no client write policy — only the service role can
+    // write here, so this value cannot be forged via the REST API. The harvest
+    // edge function validates bloom time against this row, never against the
+    // client-writable timePlanted in game_saves.grid.
+    //
+    // We insert this BEFORE the grid CAS update so that on failure we have
+    // not written a plant to the grid without a corresponding authoritative
+    // timing. If the grid update fails below we delete this row again.
+    const timingInsert = await supabaseAdmin
+      .from("plant_timings")
+      .upsert(
+        { user_id: userId, row, col, species_id: speciesId, planted_at: new Date(newPlant.timePlanted).toISOString() },
+        { onConflict: "user_id,row,col" }
+      );
+    if (timingInsert.error) {
+      console.error("plant_timings insert failed:", timingInsert.error);
+      return new Response(JSON.stringify({ error: "Internal server error" }), {
+        status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
     // ── Write to DB ───────────────────────────────────────────────────────────
     const { data: updateData, error: updateError } = await supabaseAdmin
       .from("game_saves")
@@ -146,21 +168,16 @@ Deno.serve(async (req: Request) => {
       .single();
 
     if (updateError || !updateData) {
+      // Roll back the plant_timings row so the next plant-seed call (after
+      // the client refetches state) starts cleanly.
+      await supabaseAdmin
+        .from("plant_timings")
+        .delete()
+        .eq("user_id", userId).eq("row", row).eq("col", col);
       return new Response(JSON.stringify({ error: "Save was modified by another action" }), {
         status: 409, headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
-
-    // Record server-authoritative planting time.
-    // plant_timings has no client write policy — only service role can upsert here.
-    // harvest validates bloom time against this instead of the client-writable
-    // timePlanted field stored in game_saves.grid.
-    void supabaseAdmin.from("plant_timings").upsert({
-      user_id:    userId,
-      row,
-      col,
-      planted_at: new Date(newPlant.timePlanted).toISOString(),
-    }, { onConflict: "user_id,row,col" });
 
     void supabaseAdmin.from("action_log").insert({
       user_id: userId, action: "plant_seed",

--- a/supabase/functions/remove-plant/index.ts
+++ b/supabase/functions/remove-plant/index.ts
@@ -147,6 +147,13 @@ Deno.serve(async (req: Request) => {
       });
     }
 
+    // Drop the server-authoritative timing for this plot. If we leave the row
+    // in place, a future plant-seed at the same (row,col) is protected by the
+    // upsert + species_id check, but cleaning up keeps the table tight.
+    void supabaseAdmin.from("plant_timings")
+      .delete()
+      .eq("user_id", userId).eq("row", row).eq("col", col);
+
     void supabaseAdmin.from("action_log").insert({
       user_id: userId, action: "remove_plant",
       payload: { row, col, speciesId },

--- a/supabase/functions/tick-offline-gardens/index.ts
+++ b/supabase/functions/tick-offline-gardens/index.ts
@@ -426,6 +426,50 @@ Deno.serve(async (req: Request) => {
         discovered: (raw.discovered ?? []) as string[],
       };
 
+      // Load server-authoritative planting times for this user and overwrite
+      // any client-writable plant.timePlanted in the grid before we compute
+      // growth. Without this, a user can PATCH game_saves.grid via the REST
+      // API to backdate timePlanted, then trigger this endpoint (it accepts
+      // any Authorization header) to have an active harvest bell auto-harvest
+      // their forged-bloom plants. See migration 20260428000004 for context.
+      const { data: timings } = await supabase
+        .from("plant_timings")
+        .select("row, col, species_id, planted_at")
+        .eq("user_id", raw.user_id);
+      if (timings?.length) {
+        const tmap = new Map<string, { species_id: string; planted_at: string }>();
+        for (const t of timings) tmap.set(`${t.row},${t.col}`, t);
+        let mutated = false;
+        const safeGrid = original.grid.map((r, ri) => r.map((p, ci) => {
+          if (!p.plant) return p;
+          const t = tmap.get(`${ri},${ci}`);
+          if (!t || t.species_id !== p.plant.speciesId) {
+            // Missing or mismatched timing: treat as "just planted now". This
+            // makes legacy plants restart instead of being trusted.
+            mutated = true;
+            return { ...p, plant: { ...p.plant, timePlanted: now, sproutedAt: undefined, bloomedAt: undefined, growthMs: undefined, lastTickAt: undefined } };
+          }
+          const authoritative = new Date(t.planted_at).getTime();
+          if (p.plant.timePlanted === authoritative) return p;
+          mutated = true;
+          // Replace timePlanted with the authoritative value. Drop any
+          // client-stamped checkpoints (sproutedAt / bloomedAt / growthMs /
+          // lastTickAt) that may have been forged to lie about progress.
+          return { ...p, plant: { ...p.plant, timePlanted: authoritative, sproutedAt: undefined, bloomedAt: undefined, growthMs: undefined, lastTickAt: undefined } };
+        }));
+        if (mutated) original.grid = safeGrid;
+      } else {
+        // No timings recorded for this user at all — treat every plant as
+        // just-planted now so the cron cannot auto-harvest forged blooms.
+        let mutated = false;
+        const safeGrid = original.grid.map(r => r.map(p => {
+          if (!p.plant) return p;
+          mutated = true;
+          return { ...p, plant: { ...p.plant, timePlanted: now, sproutedAt: undefined, bloomedAt: undefined, growthMs: undefined, lastTickAt: undefined } };
+        }));
+        if (mutated) original.grid = safeGrid;
+      }
+
       // 1. Stamp bloomedAt so harvest bell + mutations can find ready plants
       const { grid: stamped, changed: stampChanged } = stampBloomed(original.grid, now, weatherMult);
       let sim = stampChanged ? { ...original, grid: stamped } : original;

--- a/supabase/migrations/20260428000005_plant_timings_hardening.sql
+++ b/supabase/migrations/20260428000005_plant_timings_hardening.sql
@@ -1,0 +1,35 @@
+-- plant_timings hardening: bind each timing row to a species_id so a stale
+-- timing row from a previously removed plant cannot be used to validate a
+-- different species in the same plot. Also tightens row/col types.
+--
+-- The previous migration (20260428000004_plant_timings.sql) shipped with a
+-- legacy fallback in the harvest edge function: when no plant_timings row
+-- existed for a plot, it trusted the client-writable timePlanted from the
+-- grid JSON. Plants that predate the migration therefore remained fully
+-- exploitable. This migration is paired with edge-function changes that
+-- remove that fallback entirely.
+
+ALTER TABLE plant_timings
+  ADD COLUMN IF NOT EXISTS species_id text;
+
+-- Backfill species_id from the current grid for any timing rows that are
+-- already present. Plants without a matching grid entry are deleted (they
+-- are stale from a removed plant).
+UPDATE plant_timings pt
+SET    species_id = (
+         SELECT (gs.grid -> pt.row -> pt.col -> 'plant' ->> 'speciesId')
+         FROM   game_saves gs
+         WHERE  gs.user_id = pt.user_id
+       )
+WHERE  pt.species_id IS NULL;
+
+DELETE FROM plant_timings WHERE species_id IS NULL;
+
+ALTER TABLE plant_timings
+  ALTER COLUMN species_id SET NOT NULL;
+
+-- Sanity bounds: gardens are small grids, and an attacker calling plant-seed
+-- with extreme indices should not be able to bloat this table.
+ALTER TABLE plant_timings
+  ADD CONSTRAINT plant_timings_row_bounds CHECK (row >= 0 AND row < 64),
+  ADD CONSTRAINT plant_timings_col_bounds CHECK (col >= 0 AND col < 64);


### PR DESCRIPTION
Issue:
https://github.com/brimatt16219/Chrysanthemum/issues/126

## Summary of the fix

Five files changed:

| File | Change |
|---|---|
| supabase/migrations/20260428000005_plant_timings_hardening.sql | **New.** Adds `species_id` to `plant_timings` (with backfill from current grids), drops orphan rows, adds row/col CHECK bounds. |
| supabase/functions/harvest/index.ts | **Removes the legacy fallback to `plant.timePlanted`.** When no timing row exists (or species mismatch), lazily upserts `planted_at = now()` and rejects this harvest. |
| supabase/functions/plant-seed/index.ts | **Awaits** the `plant_timings` upsert and writes it **before** the grid CAS update. If the grid update fails, deletes the timing row. Stores `species_id`. |
| supabase/functions/remove-plant/index.ts | Deletes the `plant_timings` row when a plant is removed (so a new plant in that plot can't inherit a stale time — defense in depth on top of the species_id check). |
| supabase/functions/tick-offline-gardens/index.ts | **Closes a parallel exploit:** the cron currently trusts `grid.timePlanted` when deciding what auto-harvest bells should harvest, and accepts any auth header. Now loads `plant_timings` per user and rewrites each plant's `timePlanted` (plus drops `sproutedAt` / `bloomedAt` / `growthMs` / `lastTickAt`) to the authoritative value before any growth math. Plants without a timing row get `now()` (treated as just-planted). |

## What this means for the exploit

After deploying, the console snippet will:

1. PATCH `game_saves.grid` successfully (RLS still allows it — that's required for `saveToCloud`).
2. Click harvest → harvest function reads `plant_timings`, sees a real row whose `planted_at` is the original plant time, ignores the forged `grid.timePlanted`, returns 400 "not ready". 
3. For pre-existing plants without a row, harvest backfills `planted_at = now()` and rejects, so the plant just restarts growth. **Single-use lazy backfill, no permanent fallback.**
4. Triggering `tick-offline-gardens` no longer helps because it overwrites the plant's `timePlanted` with the authoritative one before the bell scan.

## What's still worth doing (out of scope here)

- `apply-fertilizer` and `gear-action` should be audited the same way if they read `plant.timePlanted` (didn't see exploit-relevant uses but worth a pass).
- Consider an RLS policy that forbids client UPDATEs to `game_saves.grid` entirely and routes all writes through edge functions. That removes the underlying primitive (client-controlled grid) instead of patching downstream readers.
- The `WAY_BACK = 365d` value in attacker scripts is now harmless, but if you want to detect attempts, add a server check that `plant.timePlanted > now() - someThreshold` and log/alert on violations.