### PR TITLE
fix: close timePlanted harvest exploit and correct mutation multipliers

### DIFF
--- a/supabase/functions/harvest/index.ts
+++ b/supabase/functions/harvest/index.ts
@@ -238,20 +238,39 @@ Deno.serve(async (req: Request) => {
     const masteredBonus  = Math.min(plant.masteredBonus ?? 1.0, 1.25);
 
     // Use server-authoritative planted_at from plant_timings.
-    // If no entry exists (plant predates the fix), backfill now() and reject —
-    // the plant will regrow from this moment. This closes the timePlanted exploit
-    // for all existing plants immediately rather than waiting for a full cycle.
+    // If no entry exists (plant predates the fix), backfill now() and silently
+    // clear the plot — returning 400 here causes a rollback-retry infinite loop
+    // because the client re-presents the bloomed plant after each rollback.
+    // Instead we return the idempotent 200 (no coins, no inventory change in DB)
+    // so the client keeps its optimistic grid removal and stops retrying.
     // Approach credit: @cirillojon (PR #134).
     if (!timingResult?.data) {
-      void supabaseAdmin.from("plant_timings").upsert({
-        user_id:    userId,
-        row,
-        col,
-        planted_at: new Date().toISOString(),
-      });
-      return new Response(JSON.stringify({ error: "Plant timing reset — please wait for it to regrow" }), {
-        status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      const clearedGrid = grid.map((r, ri) =>
+        r.map((p, ci) => ri === row && ci === col ? { ...p, plant: null } : p)
+      );
+      void Promise.all([
+        supabaseAdmin.from("plant_timings").upsert({
+          user_id:    userId,
+          row,
+          col,
+          planted_at: new Date().toISOString(),
+        }),
+        supabaseAdmin.from("game_saves")
+          .update({ grid: clearedGrid, updated_at: new Date().toISOString() })
+          .eq("user_id", userId)
+          .eq("updated_at", priorUpdatedAt),
+      ]);
+      return new Response(
+        JSON.stringify({
+          ok:         true,
+          coins:      save.coins as number,
+          inventory:  save.inventory ?? [],
+          discovered: save.discovered ?? [],
+          mutation:   undefined,
+          bonusCoins: 0,
+        }),
+        { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
     }
 
     const authoritativePlantedAt = new Date(timingResult.data.planted_at).getTime();

--- a/supabase/functions/harvest/index.ts
+++ b/supabase/functions/harvest/index.ts
@@ -18,8 +18,8 @@ const FERTILIZER_MULTIPLIERS: Record<string, number> = {
 
 // ── Mutation value multipliers (mirrors src/data/flowers.ts) ─────────────────
 const MUTATION_MULTIPLIERS: Record<string, number> = {
-  golden: 4.0, rainbow: 3.0, giant: 2.0, moonlit: 2.5, frozen: 2.0,
-  scorched: 2.0, wet: 1.5, windstruck: 1.1, shocked: 2.5,
+  golden: 4.0, rainbow: 5.0, giant: 2.0, moonlit: 2.5, frozen: 2.0,
+  scorched: 2.0, wet: 1.25, windstruck: 0.7, shocked: 2.5,
 };
 
 // ── Flower growth times in ms (mirrors src/data/flowers.ts) ──────────────────
@@ -233,16 +233,28 @@ Deno.serve(async (req: Request) => {
 
     const totalGrowthMs  = growthTimes.seed + growthTimes.sprout;
     const fertMultiplier = plant.fertilizer ? (FERTILIZER_MULTIPLIERS[plant.fertilizer] ?? 1.0) : 1.0;
-    const masteredBonus  = plant.masteredBonus ?? 1.0;
+    // Clamp masteredBonus — client-stored value must not exceed the legitimate
+    // max of 1.25, preventing a tampered DB row from making growth instant.
+    const masteredBonus  = Math.min(plant.masteredBonus ?? 1.0, 1.25);
 
-    // Use server-authoritative planted_at from plant_timings when available.
-    // Falls back to timePlanted for plants that predate this fix — those remain
-    // vulnerable until they are harvested and replanted, at which point plant-seed
-    // will create a plant_timings entry for them.
-    const authoritativePlantedAt = timingResult?.data?.planted_at
-      ? new Date(timingResult.data.planted_at).getTime()
-      : plant.timePlanted;
+    // Use server-authoritative planted_at from plant_timings.
+    // If no entry exists (plant predates the fix), backfill now() and reject —
+    // the plant will regrow from this moment. This closes the timePlanted exploit
+    // for all existing plants immediately rather than waiting for a full cycle.
+    // Approach credit: @cirillojon (PR #134).
+    if (!timingResult?.data) {
+      void supabaseAdmin.from("plant_timings").upsert({
+        user_id:    userId,
+        row,
+        col,
+        planted_at: new Date().toISOString(),
+      });
+      return new Response(JSON.stringify({ error: "Plant timing reset — please wait for it to regrow" }), {
+        status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
 
+    const authoritativePlantedAt = new Date(timingResult.data.planted_at).getTime();
     const minBloomTime = authoritativePlantedAt + totalGrowthMs / (fertMultiplier * masteredBonus * MAX_WEATHER_MULTIPLIER);
 
     if (Date.now() < minBloomTime) {


### PR DESCRIPTION
## Summary

- **#126 (CVE 10.0)** — Completes the `plant_timings` fix from #130. The fallback to client-supplied `timePlanted` left all existing plants exploitable since no `plant_timings` entries existed yet. Drops the fallback entirely: plants without a timing entry have `planted_at` backfilled to `now()` and the plot is silently cleared (200, no coins) so the client doesn't enter a rollback-retry loop. Approach credit: @cirillojon (PR #134).
- **#133** — Three `MUTATION_MULTIPLIERS` values in the harvest edge function were wrong vs `flowers.ts`: `rainbow 3.0 → 5.0`, `wet 1.5 → 1.25`, `windstruck 1.1 → 0.7` (penalty, not a bonus). Also clamps `masteredBonus` to `Math.min(val, 1.25)` server-side to prevent a tampered DB row from making bloom time instant.

## Test plan

- [ ] Plant a flower, immediately run the localStorage `timePlanted` exploit (Test A) — harvest returns 400 "Plant is not ready to harvest", no coins paid
- [ ] Plant a flower, PATCH `game_saves` directly via REST to set `timePlanted` a year in the past (Test B) — same result, `plant_timings` authoritative timestamp holds
- [ ] Verify `windstruck` mutation harvest gives a coin penalty (not a bonus) vs base sell value
- [ ] Verify `rainbow` mutation gives 5× base value, `wet` gives 1.25×
