### PR TITLE
fix: CAS guard on saveToCloud to block stale session overwrites (#131)

### DIFF
--- a/src/lib/edgeFunctions.ts
+++ b/src/lib/edgeFunctions.ts
@@ -36,12 +36,14 @@ export interface HarvestResult {
   discovered: GameState["discovered"];
   mutation:   string | undefined;
   bonusCoins: number;
+  serverUpdatedAt: string;
 }
 
 export interface PlantSeedResult {
   ok:        true;
   grid:      GameState["grid"];
   inventory: GameState["inventory"];
+  serverUpdatedAt: string;
 }
 
 export interface ShopActionResult {
@@ -50,12 +52,14 @@ export interface ShopActionResult {
   shop:        GameState["shop"];
   inventory:   GameState["inventory"];
   fertilizers: GameState["fertilizers"];
+  serverUpdatedAt: string;
 }
 
 export interface ApplyFertilizerResult {
   ok:          true;
   grid:        GameState["grid"];
   fertilizers: GameState["fertilizers"];
+  serverUpdatedAt: string;
 }
 
 export interface UpgradeResult {
@@ -68,12 +72,14 @@ export interface UpgradeResult {
   // shop slot upgrade fields
   shop_slots?: number;
   shop?:       GameState["shop"];
+  serverUpdatedAt: string;
 }
 
 export interface BotanyResult {
   ok:              true;
   inventory:       GameState["inventory"];
   outputSpeciesIds: string[];
+  serverUpdatedAt: string;
 }
 
 // ── Typed callers ─────────────────────────────────────────────────────────────
@@ -100,6 +106,7 @@ export interface RemovePlantResult {
   ok:        true;
   grid:      GameState["grid"];
   inventory: GameState["inventory"];
+  serverUpdatedAt: string;
 }
 
 export function edgeRemovePlant(row: number, col: number) {
@@ -152,6 +159,7 @@ export interface GearActionResult {
   grid:          GameState["grid"];
   gearInventory?: GameState["gearInventory"];
   fertilizers?:  GameState["fertilizers"];
+  serverUpdatedAt: string;
 }
 
 export function edgePlaceGear(row: number, col: number, gearType: string, direction?: string) {
@@ -178,6 +186,7 @@ export interface SupplyBuyResult {
   supplyShop:    GameState["supplyShop"];
   fertilizers:   GameState["fertilizers"];
   gearInventory: GameState["gearInventory"];
+  serverUpdatedAt: string;
 }
 
 export function edgeBuyFromSupplyShop(slotId: string) {
@@ -201,12 +210,14 @@ export function edgeBotanyConvertAll(rarity: string) {
 export interface SendGiftResult {
   ok:        true;
   inventory: GameState["inventory"];
+  serverUpdatedAt: string;
 }
 
 export interface ClaimGiftResult {
   ok:         true;
   inventory:  GameState["inventory"];
   discovered: GameState["discovered"];
+  serverUpdatedAt: string;
 }
 
 export function edgeSendGift(
@@ -231,18 +242,21 @@ export interface MarketplaceListResult {
   fertilizers?:   GameState["fertilizers"];
   gearInventory?: GameState["gearInventory"];
   listingId:      string;
+  serverUpdatedAt: string;
 }
 
 export interface MarketplaceUpgradeSlotsResult {
   ok:               true;
   coins:            number;
   marketplaceSlots: number;
+  serverUpdatedAt:  string;
 }
 
 export interface MarketplaceBuyResult {
   ok:    true;
   coins: number;
   // Item is delivered via mailbox — no direct inventory update
+  serverUpdatedAt: string;
 }
 
 export interface ClaimMailResult {
@@ -254,6 +268,7 @@ export interface ClaimMailResult {
   gearInventory:  GameState["gearInventory"];
   discovered:     GameState["discovered"];
   alreadyClaimed?: boolean;
+  serverUpdatedAt: string;
 }
 
 export interface MarketplaceCancelResult {
@@ -261,6 +276,7 @@ export interface MarketplaceCancelResult {
   inventory:      GameState["inventory"];
   fertilizers?:   GameState["fertilizers"];
   gearInventory?: GameState["gearInventory"];
+  serverUpdatedAt: string;
 }
 
 export function edgeMarketplaceCreateListing(

--- a/src/store/cloudSave.ts
+++ b/src/store/cloudSave.ts
@@ -137,6 +137,7 @@ export async function loadCloudSave(userId: string): Promise<GameState | null> {
       supplyShop:           (data.supply_shop     as GameState["supplyShop"])     ?? [],
       supplySlots:          (data.supply_slots    as number)                      ?? 2,
       lastSupplyReset:      (data.last_supply_reset as number)                    ?? 0,
+      serverUpdatedAt:      (data.updated_at as string) ?? null,
     } as GameState;
   } catch {
     return null;
@@ -147,32 +148,50 @@ export async function saveToCloud(
   userId: string,
   state: GameState
 ): Promise<boolean> {
-  const { error } = await supabase
-    .from("game_saves")
-    .upsert({
-      user_id:                userId,
-      coins:                  state.coins,
-      farm_size:              state.farmSize,
-      farm_rows:              state.farmRows,
-      shop_slots:             state.shopSlots,
-      grid:                   state.grid,
-      inventory:              state.inventory,
-      fertilizers:            state.fertilizers,
-      shop:                   state.shop,
-      last_shop_reset:        state.lastShopReset,
-      last_saved:             Date.now(),
-      weather_forecast_slots: state.weatherForecastSlots ?? 0,
-      marketplace_slots:      state.marketplaceSlots ?? 0,
-      // Farm Update fields
-      gear_inventory:         state.gearInventory     ?? [],
-      supply_shop:            state.supplyShop        ?? [],
-      supply_slots:           state.supplySlots       ?? 2,
-      last_supply_reset:      state.lastSupplyReset   ?? 0,
-      updated_at:             new Date().toISOString(),
-    });
+  const payload = {
+    user_id:                userId,
+    coins:                  state.coins,
+    farm_size:              state.farmSize,
+    farm_rows:              state.farmRows,
+    shop_slots:             state.shopSlots,
+    grid:                   state.grid,
+    inventory:              state.inventory,
+    fertilizers:            state.fertilizers,
+    shop:                   state.shop,
+    last_shop_reset:        state.lastShopReset,
+    last_saved:             Date.now(),
+    weather_forecast_slots: state.weatherForecastSlots ?? 0,
+    marketplace_slots:      state.marketplaceSlots ?? 0,
+    gear_inventory:         state.gearInventory     ?? [],
+    supply_shop:            state.supplyShop        ?? [],
+    supply_slots:           state.supplySlots       ?? 2,
+    last_supply_reset:      state.lastSupplyReset   ?? 0,
+    updated_at:             new Date().toISOString(),
+  };
 
-  if (error) {
-    console.error("Failed to save to cloud:", error);
+  // ── First save (new account) — no prior DB row exists ────────────────────
+  if (!state.serverUpdatedAt) {
+    const { error } = await supabase.from("game_saves").upsert(payload);
+    if (error) { console.error("Failed to save to cloud:", error); return false; }
+    return true;
+  }
+
+  // ── CAS update — only overwrite if DB updated_at matches last known value ─
+  // If another session (or an edge function) wrote to the DB since we last
+  // synced, updated_at will have changed and this UPDATE will match 0 rows.
+  // We return false so the caller knows to re-fetch rather than clobber
+  // server-authoritative state (inventory, coins, etc.) with stale data.
+  const { data, error } = await supabase
+    .from("game_saves")
+    .update(payload)
+    .eq("user_id", userId)
+    .eq("updated_at", state.serverUpdatedAt)
+    .select("updated_at")
+    .single();
+
+  if (error || !data) {
+    // Either a real DB error or a CAS miss (stale session) — either way, don't overwrite.
+    if (error?.code !== "PGRST116") console.error("Failed to save to cloud:", error);
     return false;
   }
   return true;

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -94,6 +94,10 @@ export interface GameState {
   supplyShop:       ShopSlot[];
   lastSupplyReset:  number;
   gearInventory:    GearInventoryItem[];
+  // Server sync — the updated_at value from the last successful DB read or write.
+  // saveToCloud uses this as a CAS guard so stale sessions can't overwrite
+  // server-authoritative state (inventory, coins, etc.) with stale client data.
+  serverUpdatedAt:  string | null;
 }
 
 export interface OfflineSummary {
@@ -346,6 +350,7 @@ export function defaultState(): GameState {
     supplyShop:           generateSupplyShop(DEFAULT_SUPPLY_SLOTS),
     lastSupplyReset:      now,
     gearInventory:        [],
+    serverUpdatedAt:      null,
   };
 }
 

--- a/supabase/functions/apply-fertilizer/index.ts
+++ b/supabase/functions/apply-fertilizer/index.ts
@@ -125,12 +125,14 @@ Deno.serve(async (req: Request) => {
       .filter((f) => f.quantity > 0);
 
     // ── Write to DB ───────────────────────────────────────────────────────────
-    const { error: updateError } = await supabaseAdmin
+    const { data: updateData, error: updateError } = await supabaseAdmin
       .from("game_saves")
       .update({ grid: newGrid, fertilizers: newFertilizers, updated_at: new Date().toISOString() })
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .select("updated_at")
+      .single();
 
-    if (updateError) {
+    if (updateError || !updateData) {
       return new Response(JSON.stringify({ error: "Failed to save" }), {
         status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -143,7 +145,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, grid: newGrid, fertilizers: newFertilizers }),
+      JSON.stringify({ ok: true, grid: newGrid, fertilizers: newFertilizers, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (err) {

--- a/supabase/functions/botany-convert/index.ts
+++ b/supabase/functions/botany-convert/index.ts
@@ -293,7 +293,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, inventory, outputSpeciesIds }),
+      JSON.stringify({ ok: true, inventory, outputSpeciesIds, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (err) {

--- a/supabase/functions/claim-gift/index.ts
+++ b/supabase/functions/claim-gift/index.ts
@@ -164,7 +164,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, inventory, discovered }),
+      JSON.stringify({ ok: true, inventory, discovered, serverUpdatedAt: updateResult.data.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
 

--- a/supabase/functions/claim-mail/index.ts
+++ b/supabase/functions/claim-mail/index.ts
@@ -173,7 +173,7 @@ Deno.serve(async (req: Request) => {
         gear_inventory: gearInventory,
         discovered,
         updated_at:     new Date().toISOString(),
-      }).eq("user_id", userId),
+      }).eq("user_id", userId).select("updated_at").single(),
     ]);
 
     if (claimResult.error) {
@@ -182,7 +182,7 @@ Deno.serve(async (req: Request) => {
         status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
-    if (updateResult.error) {
+    if (updateResult.error || !updateResult.data) {
       console.error("claim-mail: save update failed", updateResult.error);
       return new Response(JSON.stringify({ error: "Failed to update save" }), {
         status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -195,7 +195,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, kind, coins, inventory, fertilizers, gearInventory, discovered }),
+      JSON.stringify({ ok: true, kind, coins, inventory, fertilizers, gearInventory, discovered, serverUpdatedAt: updateResult.data.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
 

--- a/supabase/functions/gear-action/index.ts
+++ b/supabase/functions/gear-action/index.ts
@@ -145,7 +145,7 @@ Deno.serve(async (req: Request) => {
         payload: { gearType, row, col }, result: { placedAt },
       });
 
-      return json({ ok: true, grid, gearInventory });
+      return json({ ok: true, grid, gearInventory, serverUpdatedAt: ud.updated_at });
     }
 
     // ── remove ────────────────────────────────────────────────────────────────
@@ -185,7 +185,7 @@ Deno.serve(async (req: Request) => {
         payload: { gearType, row, col }, result: { storedReturned: stored.length, gearDestroyed: true },
       });
 
-      return json({ ok: true, grid, gearInventory, fertilizers });
+      return json({ ok: true, grid, gearInventory, fertilizers, serverUpdatedAt: ud.updated_at });
     }
 
     // ── collect (composter) ───────────────────────────────────────────────────
@@ -226,7 +226,7 @@ Deno.serve(async (req: Request) => {
         payload: { row, col }, result: { collected: stored.length },
       });
 
-      return json({ ok: true, grid, fertilizers });
+      return json({ ok: true, grid, fertilizers, serverUpdatedAt: ud.updated_at });
     }
 
     // ── set_direction (fan) ───────────────────────────────────────────────────
@@ -253,7 +253,7 @@ Deno.serve(async (req: Request) => {
 
       if (ue || !ud) return err("Save was modified by another action", 409);
 
-      return json({ ok: true, grid });
+      return json({ ok: true, grid, serverUpdatedAt: ud.updated_at });
     }
 
     return err("Unhandled action");

--- a/supabase/functions/harvest/index.ts
+++ b/supabase/functions/harvest/index.ts
@@ -346,7 +346,7 @@ Deno.serve(async (req: Request) => {
 
     // Return coins/inventory/discovered only — NOT grid (see comment above).
     return new Response(
-      JSON.stringify({ ok: true, coins: newCoins, inventory: newInventory, discovered: newDiscovered, mutation, bonusCoins }),
+      JSON.stringify({ ok: true, coins: newCoins, inventory: newInventory, discovered: newDiscovered, mutation, bonusCoins, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (err) {

--- a/supabase/functions/marketplace-buy/index.ts
+++ b/supabase/functions/marketplace-buy/index.ts
@@ -207,7 +207,7 @@ Deno.serve(async (req: Request) => {
     }
 
     return new Response(
-      JSON.stringify({ ok: true, coins: newBuyerCoins }),
+      JSON.stringify({ ok: true, coins: newBuyerCoins, serverUpdatedAt: coinResult.data.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
 

--- a/supabase/functions/marketplace-cancel/index.ts
+++ b/supabase/functions/marketplace-cancel/index.ts
@@ -152,12 +152,14 @@ Deno.serve(async (req: Request) => {
     }
 
     // Return item to save
-    const { error: updateError } = await supabaseAdmin
+    const { data: updateData, error: updateError } = await supabaseAdmin
       .from("game_saves")
       .update({ inventory, fertilizers, gear_inventory: gearInventory, updated_at: new Date().toISOString() })
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .select("updated_at")
+      .single();
 
-    if (updateError) {
+    if (updateError || !updateData) {
       console.error("marketplace-cancel: save update failed after cancel", updateError);
       return new Response(JSON.stringify({ error: "Failed to update save" }), {
         status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -165,7 +167,7 @@ Deno.serve(async (req: Request) => {
     }
 
     return new Response(
-      JSON.stringify({ ok: true, inventory, fertilizers, gearInventory }),
+      JSON.stringify({ ok: true, inventory, fertilizers, gearInventory, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
 

--- a/supabase/functions/marketplace-list/index.ts
+++ b/supabase/functions/marketplace-list/index.ts
@@ -201,7 +201,7 @@ Deno.serve(async (req: Request) => {
       }
 
       return new Response(
-        JSON.stringify({ ok: true, coins, marketplaceSlots }),
+        JSON.stringify({ ok: true, coins, marketplaceSlots, serverUpdatedAt: updateData.updated_at }),
         { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
       );
     }
@@ -303,7 +303,7 @@ Deno.serve(async (req: Request) => {
         }
 
         return new Response(
-          JSON.stringify({ ok: true, coins, fertilizers: newFertilizers, inventory: newInventory, listingId: listing.id }),
+          JSON.stringify({ ok: true, coins, fertilizers: newFertilizers, inventory: newInventory, listingId: listing.id, serverUpdatedAt: updateData.updated_at }),
           { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
         );
       }
@@ -373,7 +373,7 @@ Deno.serve(async (req: Request) => {
         }
 
         return new Response(
-          JSON.stringify({ ok: true, coins, gearInventory: newGearInventory, inventory: newInventory, listingId: listing.id }),
+          JSON.stringify({ ok: true, coins, gearInventory: newGearInventory, inventory: newInventory, listingId: listing.id, serverUpdatedAt: updateData2.updated_at }),
           { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
         );
       }
@@ -448,7 +448,7 @@ Deno.serve(async (req: Request) => {
       }
 
       return new Response(
-        JSON.stringify({ ok: true, coins, inventory: newInventory, listingId: listing.id }),
+        JSON.stringify({ ok: true, coins, inventory: newInventory, listingId: listing.id, serverUpdatedAt: updateData3.updated_at }),
         { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
       );
     }

--- a/supabase/functions/plant-seed/index.ts
+++ b/supabase/functions/plant-seed/index.ts
@@ -169,7 +169,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, grid: newGrid, inventory: newInventory }),
+      JSON.stringify({ ok: true, grid: newGrid, inventory: newInventory, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (err) {

--- a/supabase/functions/remove-plant/index.ts
+++ b/supabase/functions/remove-plant/index.ts
@@ -136,12 +136,14 @@ Deno.serve(async (req: Request) => {
       : [...inventory, { speciesId, quantity: 1, isSeed: true }];
 
     // ── Write to DB ───────────────────────────────────────────────────────────
-    const { error: updateError } = await supabaseAdmin
+    const { data: updateData, error: updateError } = await supabaseAdmin
       .from("game_saves")
       .update({ grid: newGrid, inventory: newInventory, updated_at: new Date().toISOString() })
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .select("updated_at")
+      .single();
 
-    if (updateError) {
+    if (updateError || !updateData) {
       return new Response(JSON.stringify({ error: "Failed to save" }), {
         status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -153,7 +155,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, grid: newGrid, inventory: newInventory }),
+      JSON.stringify({ ok: true, grid: newGrid, inventory: newInventory, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
 

--- a/supabase/functions/send-gift/index.ts
+++ b/supabase/functions/send-gift/index.ts
@@ -174,7 +174,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, inventory }),
+      JSON.stringify({ ok: true, inventory, serverUpdatedAt: updateResult.data.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
 

--- a/supabase/functions/shop-action/index.ts
+++ b/supabase/functions/shop-action/index.ts
@@ -249,7 +249,7 @@ Deno.serve(async (req: Request) => {
     void supabaseAdmin.from("action_log").insert({ user_id: userId, action, payload: body, result: logResult });
 
     return new Response(
-      JSON.stringify({ ok: true, coins, shop: newShop, inventory: newInventory, fertilizers: newFertilizers }),
+      JSON.stringify({ ok: true, coins, shop: newShop, inventory: newInventory, fertilizers: newFertilizers, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (err) {

--- a/supabase/functions/supply-action/index.ts
+++ b/supabase/functions/supply-action/index.ts
@@ -147,7 +147,7 @@ Deno.serve(async (req: Request) => {
         return err("Slot has invalid type — not fertilizer or gear");
       }
 
-      const { error: ue } = await supabaseAdmin
+      const { data: ud, error: ue } = await supabaseAdmin
         .from("game_saves")
         .update({
           coins,
@@ -156,9 +156,11 @@ Deno.serve(async (req: Request) => {
           gear_inventory: gearInventory,
           updated_at:    new Date().toISOString(),
         })
-        .eq("user_id", userId);
+        .eq("user_id", userId)
+        .select("updated_at")
+        .single();
 
-      if (ue) return err("Failed to save", 500);
+      if (ue || !ud) return err("Failed to save", 500);
 
       void supabaseAdmin.from("action_log").insert({
         user_id: userId, action: "supply_buy",
@@ -166,7 +168,7 @@ Deno.serve(async (req: Request) => {
         result:  { coins, type: slot.isFertilizer ? "fertilizer" : "gear" },
       });
 
-      return json({ ok: true, coins, supplyShop, fertilizers, gearInventory });
+      return json({ ok: true, coins, supplyShop, fertilizers, gearInventory, serverUpdatedAt: ud.updated_at });
     }
 
     return err("Unhandled action");

--- a/supabase/functions/upgrade/index.ts
+++ b/supabase/functions/upgrade/index.ts
@@ -213,12 +213,14 @@ Deno.serve(async (req: Request) => {
     }
 
     // ── Write to DB ───────────────────────────────────────────────────────────
-    const { error: updateError } = await supabaseAdmin
+    const { data: updateData, error: updateError } = await supabaseAdmin
       .from("game_saves")
       .update({ ...updatePayload, updated_at: new Date().toISOString() })
-      .eq("user_id", userId);
+      .eq("user_id", userId)
+      .select("updated_at")
+      .single();
 
-    if (updateError) {
+    if (updateError || !updateData) {
       return new Response(JSON.stringify({ error: "Failed to save" }), {
         status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -230,7 +232,7 @@ Deno.serve(async (req: Request) => {
     });
 
     return new Response(
-      JSON.stringify({ ok: true, ...updatePayload }),
+      JSON.stringify({ ok: true, ...updatePayload, serverUpdatedAt: updateData.updated_at }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   } catch (err) {


### PR DESCRIPTION
## Summary

- `saveToCloud` used a plain `upsert` with no concurrency guard, allowing a stale client session to overwrite server-authoritative inventory/coins with old data
- Attack: open game on two devices → device 2 goes stale → device 1 lists a marketplace item → device 2 auto-saves, restoring the item to DB inventory → duplicate listing possible
- Fix: introduce `serverUpdatedAt` to `GameState` (populated from DB `updated_at` on every load and edge function response); `saveToCloud` now does `UPDATE WHERE updated_at = serverUpdatedAt` — if another session wrote first, the stale write is silently rejected


Closes #131