### PR TITLE
feat(boosts): Phase 5a — active speed-boost consumables

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { GiftNotification } from "./components/GiftNotification";
 import { Codex } from "./components/Codex";
 import { Botany } from "./components/Botany";
 import { CraftingTab } from "./components/CraftingTab";
+import { ActiveBoostsHUD } from "./components/ActiveBoostsHUD";
 import { MarketplaceTab } from "./components/MarketplaceTab";
 import { WeatherOverlay } from "./components/WeatherOverlay";
 import { DevWeatherPanel } from "./components/DevWeatherPanel";
@@ -479,6 +480,7 @@ function AppInner() {
                 period={dayPeriod}
               />
             </button>
+            <ActiveBoostsHUD activeBoosts={state.activeBoosts} />
             <span className="text-sm font-mono">🟡 {state.coins.toLocaleString()}</span>
             {!authLoading && (
               user ? (

--- a/src/components/ActiveBoostsHUD.tsx
+++ b/src/components/ActiveBoostsHUD.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import type { ActiveBoost } from "../store/gameStore";
+
+const BOOST_DISPLAY: Record<ActiveBoost["type"], { emoji: string; label: string }> = {
+  growth:     { emoji: "🌿", label: "Verdant Rush" },
+  craft:      { emoji: "⚒️", label: "Forge Haste" },
+  attunement: { emoji: "🌀", label: "Resonance Draft" },
+};
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return "0s";
+  const totalSec = Math.ceil(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+interface Props {
+  activeBoosts: ActiveBoost[] | undefined;
+}
+
+/** Tiny HUD strip near the coin counter showing currently-active speed boosts.
+ *  One badge per boost type; each shows emoji + remaining time, ticks every second.
+ *  Renders nothing when no boosts are active. */
+export function ActiveBoostsHUD({ activeBoosts }: Props) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const live = (activeBoosts ?? []).filter(
+    (b) => new Date(b.expiresAt).getTime() > now,
+  );
+
+  if (live.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {live.map((b) => {
+        const cfg       = BOOST_DISPLAY[b.type];
+        const remaining = new Date(b.expiresAt).getTime() - now;
+        return (
+          <span
+            key={b.type}
+            title={`${cfg.label} — 2× speed (${formatRemaining(remaining)} left)`}
+            className="flex items-center gap-1 text-[11px] font-mono px-1.5 py-0.5 rounded-full border border-amber-500/40 bg-amber-500/10 text-amber-300"
+          >
+            <span className="leading-none">{cfg.emoji}</span>
+            <span>{formatRemaining(remaining)}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/CraftingTab.tsx
+++ b/src/components/CraftingTab.tsx
@@ -19,6 +19,21 @@ import {
   edgeUpgradeCraftingSlots,
 } from "../lib/edgeFunctions";
 import type { GameState, CraftingQueueEntry } from "../store/gameStore";
+import { getBoostMultiplier } from "../store/gameStore";
+
+// ── Forge Haste / Resonance Draft (Phase 5a) ───────────────────────────────────
+// If the relevant boost is active when a craft starts, halve its durationMs.
+// Mirrors the server-side logic in craft-start/index.ts.
+function applyCraftBoost(
+  rawDurationMs: number,
+  kind:          "gear" | "consumable" | "attunement",
+  state:         GameState,
+  now:           number,
+): number {
+  const boostType = kind === "attunement" ? "attunement" : "craft";
+  const mult      = getBoostMultiplier(state.activeBoosts, boostType, now);
+  return mult > 1 ? Math.max(1, Math.floor(rawDurationMs / mult)) : rawDurationMs;
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -658,7 +673,7 @@ export function CraftingTab() {
           kind:            "gear",
           outputId:        gearType,
           startedAt:       new Date().toISOString(),
-          durationMs:      recipe.durationMs,
+          durationMs:      applyCraftBoost(recipe.durationMs, "gear", cur, Date.now()),
           ...(essenceCosts.length    && { essenceCosts }),
           ...(gearCosts.length       && { gearCosts }),
           ...(consumableCosts.length && { consumableCosts }),
@@ -724,7 +739,10 @@ export function CraftingTab() {
           kind:      "consumable",
           outputId:  id,
           startedAt: new Date().toISOString(),
-          durationMs,
+          // Boost only adjusts the optimistic display — server halves its own
+          // copy when it sees an active boost, and we read durationMs back from
+          // res.craftingQueue when the server responds.
+          durationMs: applyCraftBoost(durationMs, "consumable", cur, Date.now()),
           ...(essenceCosts.length    && { essenceCosts }),
           ...(consumableCosts.length && { consumableCosts }),
         };
@@ -785,7 +803,8 @@ export function CraftingTab() {
           kind:      "attunement",
           outputId,
           startedAt: new Date().toISOString(),
-          durationMs,
+          // Boost only adjusts the optimistic display; server halves its own copy.
+          durationMs: applyCraftBoost(durationMs, "attunement", cur, Date.now()),
           ...(essenceCosts.length    && { essenceCosts }),
           ...(attunementCosts.length && { attunementCosts }),
         };

--- a/src/components/Inventory.tsx
+++ b/src/components/Inventory.tsx
@@ -5,7 +5,7 @@ import type { MutationType } from "../data/flowers";
 import { FlowerTypeBadges } from "./FlowerTypeBadges";
 import { InventoryItemCard } from "./InventoryItemCard";
 import { sellFlower, applyEclipseTonic, type InventoryItem } from "../store/gameStore";
-import { edgeSellAll, edgeUseEclipseTonic, edgeAlchemyCraftSeed } from "../lib/edgeFunctions";
+import { edgeSellAll, edgeUseEclipseTonic, edgeAlchemyCraftSeed, edgeActivateBoost } from "../lib/edgeFunctions";
 import { FERTILIZERS } from "../data/upgrades";
 import { GEAR } from "../data/gear";
 import type { GearInventoryItem } from "../data/gear";
@@ -26,6 +26,7 @@ export function Inventory({ newSeeds = 0, newBlooms = 0, newSupplies = 0, onSubT
   const [tab,                 setTab]                 = useState<Tab>(0);
   const [usingEclipse,        setUsingEclipse]        = useState<string | null>(null);
   const [openingPouch,        setOpeningPouch]        = useState<string | null>(null);
+  const [activatingBoost,     setActivatingBoost]     = useState<string | null>(null);
   const [pouchResult,         setPouchResult]         = useState<{ speciesId: string } | null>(null);
   const [pouchResultVisible,  setPouchResultVisible]  = useState(false);
 
@@ -134,6 +135,28 @@ export function Inventory({ newSeeds = 0, newBlooms = 0, newSupplies = 0, onSubT
       // silent — pouch stays in inventory on failure
     } finally {
       setOpeningPouch(null);
+    }
+  }
+
+  // Phase 5a — activate a Verdant Rush / Forge Haste / Resonance Draft.
+  // No optimistic state because the duration depends on consumable tier and we
+  // already trust the server response. Roundtrip is one quick edge call.
+  async function handleActivateBoost(consumableId: ConsumableId) {
+    if (activatingBoost) return;
+    setActivatingBoost(consumableId);
+    try {
+      const res = await edgeActivateBoost(consumableId);
+      const cur = getState();
+      update({
+        ...cur,
+        consumables:     res.consumables,
+        activeBoosts:    res.activeBoosts,
+        serverUpdatedAt: res.serverUpdatedAt,
+      });
+    } catch {
+      // silent — server rejected (e.g. CAS miss); the consumable wasn't deducted
+    } finally {
+      setActivatingBoost(null);
     }
   }
 
@@ -259,8 +282,11 @@ export function Inventory({ newSeeds = 0, newBlooms = 0, newSupplies = 0, onSubT
               lastEclipseTonic={state.lastEclipseTonic}
               usingEclipse={usingEclipse}
               openingPouch={openingPouch}
+              activatingBoost={activatingBoost}
+              activeBoosts={state.activeBoosts ?? []}
               onUseEclipse={handleUseEclipseTonic}
               onOpenPouch={handleOpenPouch}
+              onActivateBoost={handleActivateBoost}
             />
           ) : (
             <EmptyTab emoji="🧪" message="No consumables" hint="Craft consumables in the Alchemy lab." />
@@ -393,12 +419,16 @@ interface ConsumablesTabProps {
   lastEclipseTonic: string | null;
   usingEclipse:     string | null;
   openingPouch:     string | null;
+  activatingBoost:  string | null;
+  activeBoosts:     { type: string; expiresAt: string; consumableId: string }[];
   onUseEclipse:     (id: ConsumableId) => void;
   onOpenPouch:      (id: ConsumableId) => void;
+  onActivateBoost:  (id: ConsumableId) => void;
 }
 
 function ConsumablesTabContent({
-  consumables, lastEclipseTonic, usingEclipse, openingPouch, onUseEclipse, onOpenPouch,
+  consumables, lastEclipseTonic, usingEclipse, openingPouch, activatingBoost, activeBoosts,
+  onUseEclipse, onOpenPouch, onActivateBoost,
 }: ConsumablesTabProps) {
   const today = new Date().toISOString().slice(0, 10);
   const alreadyUsedToday = lastEclipseTonic === today;
@@ -412,9 +442,21 @@ function ConsumablesTabContent({
         const context   = USAGE_CONTEXT[prefix] ?? "Use contextually";
         const isEclipse = c.id.startsWith("eclipse_tonic_");
         const isPouch   = c.id.startsWith("seed_pouch_");
+        const isBoost   = recipe.category === "speed_boost";
         const busy      = usingEclipse === c.id;
         const usedToday = isEclipse && alreadyUsedToday;
         const opening   = openingPouch === c.id;
+        const activating = activatingBoost === c.id;
+
+        // Surface "currently active" if a boost of this type is live
+        const boostType =
+          c.id.startsWith("verdant_rush_")    ? "growth"     :
+          c.id.startsWith("forge_haste_")     ? "craft"      :
+          c.id.startsWith("resonance_draft_") ? "attunement" : null;
+        const nowMs       = Date.now();
+        const liveBoost   = boostType
+          ? activeBoosts.find((b) => b.type === boostType && new Date(b.expiresAt).getTime() > nowMs)
+          : null;
 
         return (
           <div
@@ -462,6 +504,27 @@ function ConsumablesTabContent({
                 >
                   {opening ? "Opening…" : "🎁 Open"}
                 </button>
+              )}
+
+              {isBoost && (
+                <div className="mt-2 flex items-center gap-2 flex-wrap">
+                  <button
+                    onClick={() => onActivateBoost(c.id as ConsumableId)}
+                    disabled={!!activatingBoost}
+                    className={`px-3 py-1 rounded-lg text-xs font-semibold border transition-colors ${
+                      activating
+                        ? "border-primary/40 bg-primary/20 text-primary"
+                        : "border-primary/50 text-primary hover:bg-primary/10"
+                    } disabled:opacity-40 disabled:cursor-not-allowed`}
+                  >
+                    {activating ? "Activating…" : "✨ Activate"}
+                  </button>
+                  {liveBoost && (
+                    <span className="text-[10px] text-amber-400">
+                      Active until {new Date(liveBoost.expiresAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                    </span>
+                  )}
+                </div>
               )}
             </div>
           </div>

--- a/src/components/PlotTile.tsx
+++ b/src/components/PlotTile.tsx
@@ -5,6 +5,7 @@ import {
   getCurrentStage,
   getStageProgress,
   getPassiveGrowthMultiplier,
+  getBoostMultiplier,
   harvestPlant,
 } from "../store/gameStore";
 import { getFlower, RARITY_CONFIG, MUTATIONS, type MutationType } from "../data/flowers";
@@ -85,7 +86,11 @@ export function PlotTile({
   const gear   = plot.gear;
   const species = plant ? getFlower(plant.speciesId) : null;
 
-  const gearMult = plant ? getPassiveGrowthMultiplier(getState().grid, row, col, now) : 1.0;
+  // gearMult already folds Verdant Rush in so PlotTooltip downstream gets the
+  // combined multiplier without needing a separate prop for activeBoosts.
+  const passiveMult = plant ? getPassiveGrowthMultiplier(getState().grid, row, col, now) : 1.0;
+  const boostMult   = plant ? getBoostMultiplier(getState().activeBoosts, "growth", now) : 1.0;
+  const gearMult    = passiveMult * boostMult;
   const stage    = plant ? getCurrentStage(plant, now, activeWeather, gearMult) : null;
   const progress = plant ? getStageProgress(plant, now, activeWeather, gearMult) : 0;
 

--- a/src/lib/edgeFunctions.ts
+++ b/src/lib/edgeFunctions.ts
@@ -571,3 +571,18 @@ export function edgeUseSlotLock(slotId: string) {
   return callEdge<UseConsumableResult>("use-consumable", { action: "slot_lock", consumableId: "slot_lock", slotId });
 }
 
+// ── Active speed-boost consumables (Phase 5a) ─────────────────────────────────
+
+export interface ActivateBoostResult {
+  ok:              true;
+  consumables:     GameState["consumables"];
+  activeBoosts:    GameState["activeBoosts"];
+  serverUpdatedAt: string;
+}
+
+/** Activate a speed_boost consumable (Verdant Rush, Forge Haste, Resonance Draft).
+ *  Server validates the consumable id, deducts one, and records the boost expiry. */
+export function edgeActivateBoost(consumableId: string) {
+  return callEdge<ActivateBoostResult>("use-consumable", { action: "activate_boost", consumableId });
+}
+

--- a/src/store/cloudSave.ts
+++ b/src/store/cloudSave.ts
@@ -147,6 +147,8 @@ export async function loadCloudSave(userId: string): Promise<GameState | null> {
       // Phase 3 — time-gated crafting queue
       craftingQueue:        (data.crafting_queue        as GameState["craftingQueue"])  ?? [],
       craftingSlotCount:    (data.crafting_slot_count   as number)                      ?? 1,
+      // Phase 5a — active speed-boost consumables (pruned of expired entries on offline tick)
+      activeBoosts:         (data.active_boosts         as GameState["activeBoosts"])   ?? [],
     } as GameState;
   } catch {
     return null;
@@ -189,6 +191,8 @@ export async function saveToCloud(
     // Phase 3 — time-gated crafting queue
     crafting_queue:         state.craftingQueue     ?? [],
     crafting_slot_count:    state.craftingSlotCount ?? 1,
+    // Phase 5a — active speed-boost consumables
+    active_boosts:          state.activeBoosts      ?? [],
     updated_at:             newUpdatedAt,
   };
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -91,6 +91,45 @@ export interface ShopSlot {
 
 export type CraftKind = "gear" | "consumable" | "attunement";
 
+// ── Active speed-boost consumables (Phase 5a) ─────────────────────────────────
+// Verdant Rush  → "growth"     → 2× growth speed for all plants
+// Forge Haste   → "craft"      → 2× progress on gear + consumable craft entries
+// Resonance Draft → "attunement" → 2× progress on attunement craft entries
+export type ActiveBoostType = "growth" | "craft" | "attunement";
+
+export interface ActiveBoost {
+  type:         ActiveBoostType;
+  expiresAt:    string;   // ISO timestamp
+  consumableId: string;   // e.g. "verdant_rush_3" — for UI display + telemetry
+}
+
+/** Map a speed_boost consumable id → boost type. Returns null for non-boost ids. */
+export function consumableToBoostType(consumableId: string): ActiveBoostType | null {
+  if (consumableId.startsWith("verdant_rush_"))    return "growth";
+  if (consumableId.startsWith("forge_haste_"))     return "craft";
+  if (consumableId.startsWith("resonance_draft_")) return "attunement";
+  return null;
+}
+
+/** Returns 2.0 if any unexpired boost of `type` exists, otherwise 1.0. */
+export function getBoostMultiplier(
+  activeBoosts: ActiveBoost[] | undefined,
+  type:         ActiveBoostType,
+  now:          number,
+): number {
+  if (!activeBoosts) return 1;
+  for (const b of activeBoosts) {
+    if (b.type === type && new Date(b.expiresAt).getTime() > now) return 2;
+  }
+  return 1;
+}
+
+/** Drop expired boosts. Pure — returns a new array. */
+export function pruneActiveBoosts(boosts: ActiveBoost[] | undefined, now: number): ActiveBoost[] {
+  if (!boosts || boosts.length === 0) return [];
+  return boosts.filter((b) => new Date(b.expiresAt).getTime() > now);
+}
+
 export interface CraftingQueueEntry {
   id:         string;      // server-generated uuid
   kind:       CraftKind;
@@ -143,6 +182,11 @@ export interface GameState {
   // Phase 3 — time-gated crafting queue
   craftingQueue:     CraftingQueueEntry[];
   craftingSlotCount: number;
+  // Phase 5a — active speed-boost consumables (Verdant Rush, Forge Haste, Resonance Draft).
+  // Each entry tracks one consumable activation with its expiry. Multiple of the same type
+  // are allowed but only the latest expiry matters; getBoostMultiplier returns 2× while any
+  // matching boost is unexpired, otherwise 1×.
+  activeBoosts:      ActiveBoost[];
   // Server sync — the updated_at value from the last successful DB read or write.
   // saveToCloud uses this as a CAS guard so stale sessions can't overwrite
   // server-authoritative state (inventory, coins, etc.) with stale client data.
@@ -407,6 +451,7 @@ export function defaultState(): GameState {
     lastWindShearUsed:    null,
     craftingQueue:        [],
     craftingSlotCount:    1,
+    activeBoosts:         [],
     serverUpdatedAt:      null,
   };
 }
@@ -492,6 +537,7 @@ export function applyOfflineTick(
     consumables:          save.consumables           ?? [],
     lastEclipseTonic:     save.lastEclipseTonic      ?? null,
     lastWindShearUsed:    save.lastWindShearUsed     ?? null,
+    activeBoosts:         pruneActiveBoosts(save.activeBoosts, now),
   };
 
   let shopRestocked    = false;
@@ -999,6 +1045,9 @@ export function stampStageTransitions(
   let changed = false;
   const newlyBloomedCells: [number, number][] = [];
 
+  // Verdant Rush — global 2× growth while active
+  const boostMult = getBoostMultiplier(state.activeBoosts, "growth", now);
+
   let newGrid = state.grid.map((row, ri) =>
     row.map((plot, ci) => {
       if (!plot.plant || plot.plant.bloomedAt) return plot; // fully grown — nothing to do
@@ -1011,7 +1060,7 @@ export function stampStageTransitions(
       const fertMultiplier     = plant.fertilizer ? FERTILIZERS[plant.fertilizer].speedMultiplier : 1.0;
       const weatherMultiplier  = WEATHER[weatherType].growthMultiplier;
       const masteredMultiplier = plant.masteredBonus ?? 1.0;
-      const multiplier         = fertMultiplier * weatherMultiplier * masteredMultiplier * gearMult;
+      const multiplier         = fertMultiplier * weatherMultiplier * masteredMultiplier * gearMult * boostMult;
 
       const seedMs   = species.growthTime.seed;
       const sproutMs = species.growthTime.sprout;

--- a/supabase/functions/craft-start/index.ts
+++ b/supabase/functions/craft-start/index.ts
@@ -123,7 +123,7 @@ Deno.serve(async (req: Request) => {
       supabaseAdmin.auth.getUser(token),
       supabaseAdmin
         .from("game_saves")
-        .select("coins, essences, gear_inventory, consumables, infusers, crafting_queue, crafting_slot_count, updated_at")
+        .select("coins, essences, gear_inventory, consumables, infusers, crafting_queue, crafting_slot_count, active_boosts, updated_at")
         .eq("user_id", userId)
         .single(),
     ]);
@@ -267,6 +267,25 @@ Deno.serve(async (req: Request) => {
       if (essenceCostList.length)    newEntryEssenceCosts    = essenceCostList;
       if (consumableCostList.length) newEntryConsumableCosts = consumableCostList;
       if (attunementCostList.length) newEntryAttunementCosts = attunementCostList;
+    }
+
+    // ── Apply Forge Haste / Resonance Draft (Phase 5a) ─────────────────────────
+    // Halve durationMs for new crafts started while a matching boost is active.
+    // Existing in-flight crafts are NOT retroactively boosted — keeps the math
+    // simple and exploit-proof. Players are expected to activate boosts before
+    // queueing crafts.
+    type BoostType = "growth" | "craft" | "attunement";
+    const activeBoosts = (save.active_boosts ?? []) as { type: BoostType; expiresAt: string }[];
+    const craftBoostType: BoostType | null =
+      kind === "attunement" ? "attunement" :
+      kind === "gear" || kind === "consumable" ? "craft" : null;
+
+    if (craftBoostType) {
+      const nowMs = Date.now();
+      const hasActive = activeBoosts.some(
+        (b) => b.type === craftBoostType && new Date(b.expiresAt).getTime() > nowMs,
+      );
+      if (hasActive) durationMs = Math.max(1, Math.floor(durationMs / 2));
     }
 
     // ── Build queue entry ──────────────────────────────────────────────────────

--- a/supabase/functions/use-consumable/index.ts
+++ b/supabase/functions/use-consumable/index.ts
@@ -34,6 +34,31 @@ const ECLIPSE_ADVANCE_HOURS: Record<string, number> = {
   eclipse_tonic_4: 8, eclipse_tonic_5: 16,
 };
 
+// ── Speed-boost consumables (mirrors src/data/consumables.ts) ────────────────
+// Tier → duration in ms: I=30min, II=1h, III=3h, IV=8h, V=24h
+const BOOST_DURATIONS_MS: Record<number, number> = {
+  1: 30 * 60 * 1_000,
+  2:  1 * 60 * 60 * 1_000,
+  3:  3 * 60 * 60 * 1_000,
+  4:  8 * 60 * 60 * 1_000,
+  5: 24 * 60 * 60 * 1_000,
+};
+
+type BoostType = "growth" | "craft" | "attunement";
+
+function consumableToBoostType(id: string): BoostType | null {
+  if (id.startsWith("verdant_rush_"))    return "growth";
+  if (id.startsWith("forge_haste_"))     return "craft";
+  if (id.startsWith("resonance_draft_")) return "attunement";
+  return null;
+}
+
+interface ActiveBoost {
+  type:         BoostType;
+  expiresAt:    string;  // ISO
+  consumableId: string;
+}
+
 // ── Mutation-boost vials: consumable prefix → mutation type ──────────────────
 
 const VIAL_MUTATION: Record<string, string> = {
@@ -292,7 +317,7 @@ Deno.serve(async (req: Request) => {
     if (!action)       return err("action is required");
     if (!consumableId) return err("consumableId is required");
 
-    const VALID_ACTIONS = ["apply_to_plant", "eclipse_tonic", "wind_shear", "slot_lock"];
+    const VALID_ACTIONS = ["apply_to_plant", "eclipse_tonic", "wind_shear", "slot_lock", "activate_boost"];
     if (!VALID_ACTIONS.includes(action)) return err(`Unknown action: ${action}`);
 
     const supabaseAdmin = createClient(
@@ -307,6 +332,7 @@ Deno.serve(async (req: Request) => {
       eclipse_tonic:  ", grid, last_eclipse_tonic",
       wind_shear:     ", last_wind_shear_used",
       slot_lock:      ", supply_shop",
+      activate_boost: ", active_boosts",
     } as Record<string, string>;
 
     const selectCols = `consumables, updated_at${extraCols[action] ?? ""}`;
@@ -615,6 +641,71 @@ Deno.serve(async (req: Request) => {
         ok: true,
         supplyShop: newSupplyShop,
         consumables: newConsumables,
+        serverUpdatedAt: ud.updated_at,
+      });
+    }
+
+    // ── Action: activate_boost ────────────────────────────────────────────────
+    // Verdant Rush / Forge Haste / Resonance Draft (speed_boost category).
+    // Deducts 1 of the consumable, adds an ActiveBoost entry with expiresAt =
+    // now + tier duration. If a boost of the same type is already active, the
+    // new entry takes precedence — the old one is dropped (no stacking past 2×).
+
+    if (action === "activate_boost") {
+      const boostType = consumableToBoostType(consumableId);
+      if (!boostType) return err(`Not a speed-boost consumable: ${consumableId}`);
+
+      const tier = extractTier(consumableId);
+      if (tier === null) return err("Speed-boost consumable missing tier");
+      const durationMs = BOOST_DURATIONS_MS[tier];
+      if (!durationMs) return err(`Unknown tier ${tier}`);
+
+      const newConsumables = deductConsumable(consumables, consumableId);
+      if (!newConsumables) return err("Not enough consumables");
+
+      const now      = Date.now();
+      const existing = (save.active_boosts ?? []) as ActiveBoost[];
+
+      // Drop expired entries
+      const live = existing.filter((b) => new Date(b.expiresAt).getTime() > now);
+
+      // For same-type entry: extend timer to whichever expiry is later.
+      // (Using a 24h V on top of an active 30min I shouldn't shrink the timer.)
+      const sameType         = live.find((b) => b.type === boostType);
+      const existingExpiryMs = sameType ? new Date(sameType.expiresAt).getTime() : 0;
+      const newExpiryMs      = Math.max(existingExpiryMs, now + durationMs);
+
+      const otherTypes = live.filter((b) => b.type !== boostType);
+      const newBoost: ActiveBoost = {
+        type:         boostType,
+        expiresAt:    new Date(newExpiryMs).toISOString(),
+        consumableId,
+      };
+      const newActiveBoosts = [...otherTypes, newBoost];
+
+      const { data: ud, error: ue } = await supabaseAdmin
+        .from("game_saves")
+        .update({
+          consumables:   newConsumables,
+          active_boosts: newActiveBoosts,
+          updated_at:    new Date().toISOString(),
+        })
+        .eq("user_id", userId)
+        .eq("updated_at", priorUpdatedAt)
+        .select("updated_at")
+        .single();
+
+      if (ue || !ud) return err("Save conflict — please retry", 409);
+
+      void supabaseAdmin.from("action_log").insert({
+        user_id: userId, action: "use_consumable",
+        payload: { action, consumableId, boostType, durationMs },
+      });
+
+      return json({
+        ok:              true,
+        consumables:     newConsumables,
+        activeBoosts:    newActiveBoosts,
         serverUpdatedAt: ud.updated_at,
       });
     }

--- a/supabase/migrations/20260430000010_active_boosts.sql
+++ b/supabase/migrations/20260430000010_active_boosts.sql
@@ -1,0 +1,4 @@
+-- Phase 5a: active speed-boost consumables (Verdant Rush, Forge Haste, Resonance Draft).
+-- Each row is { type: "growth" | "craft" | "attunement", expiresAt: ISO string, consumableId: string }.
+ALTER TABLE game_saves
+  ADD COLUMN IF NOT EXISTS active_boosts JSONB NOT NULL DEFAULT '[]';


### PR DESCRIPTION
## Summary

Three speed-boost consumables now do something. Each doubles the relevant rate for its tier's duration (30 min → 24 hr).

- **Verdant Rush** → 2× growth speed for all plants
- **Forge Haste** → 2× speed on gear + consumable craft queue entries
- **Resonance Draft** → 2× speed on attunement craft queue entries

## Schema

- New `active_boosts` JSONB column on `game_saves` — migration `20260430000010_active_boosts.sql` (already pushed to remote)

## Backend

- `use-consumable` gains `activate_boost` action: validates the consumable id, deducts one, records boost expiry with **whichever-later** semantics (re-activating doesn't shrink the timer).
- `craft-start` reads `active_boosts` and halves `durationMs` for new queue entries when the matching boost is active. **In-flight crafts are NOT retroactively boosted** — keeps the math exploit-proof and matches the natural "activate then queue" play pattern.

## Frontend

- `GameState.activeBoosts` + helpers (`ActiveBoost`, `getBoostMultiplier`, `pruneActiveBoosts`, `consumableToBoostType`). Pruned on `applyOfflineTick`, persisted via `cloudSave.ts`.
- Verdant Rush threaded into `stampStageTransitions` (live tick) and `PlotTile.tsx` (display countdown).
- Forge Haste / Resonance Draft mirrored client-side via `applyCraftBoost` so optimistic queue entries match the server's halved `durationMs`.
- "✨ Activate" button on every `speed_boost` consumable in the Inventory tab, with inline "Active until HH:MM" indicator.
- New `ActiveBoostsHUD` next to the coin counter — per-type emoji + countdown, ticks each second.

## Test plan

- [ ] Craft a Verdant Rush I → "Activate" appears in inventory → click → consumable deducts, HUD shows 🌿 timer, button shows "Active until HH:MM"
- [ ] With Verdant Rush active, plant a seed → growth bar fills 2× faster (visible at minute scale)
- [ ] Activate Verdant Rush III on top of an active I → HUD timer extends to the longer expiry (whichever-later)
- [ ] Forge Haste active → start a gear craft → queue entry shows half the normal `durationMs`
- [ ] Forge Haste active → start an attunement craft → NOT halved (wrong type)
- [ ] Resonance Draft active → attunement craft halved; gear craft unaffected
- [ ] Activate boost AFTER queueing crafts → existing crafts unchanged (this is intentional)
- [ ] Boost expires → HUD badge disappears at expiry; new crafts no longer halved
- [ ] Hard refresh while boost active → HUD restores from cloud save