### PR TITLE
feat(magnifying-glass): Phase 5b — lock-in mutation reveal + dev panel consumables

### DIFF
--- a/src/components/DevWeatherPanel.tsx
+++ b/src/components/DevWeatherPanel.tsx
@@ -8,6 +8,7 @@ import { FERTILIZERS } from "../data/upgrades";
 import type { FertilizerType } from "../data/upgrades";
 import { GEAR } from "../data/gear";
 import type { GearType } from "../data/gear";
+import { CONSUMABLE_RECIPES, type ConsumableId } from "../data/consumables";
 import { useGame } from "../store/GameContext";
 import { codexKey, setDevMutationMultiplier, getDevMutationMultiplier, setDevShowGrowthDebug, getDevShowGrowthDebug } from "../store/gameStore";
 import type { GameState } from "../store/gameStore";
@@ -66,6 +67,9 @@ export function DevWeatherPanel() {
   const [fertQty, setFertQty]       = useState(5);
   const [gearType, setGearType]     = useState<GearType>("sprinkler_rare");
   const [gearQty, setGearQty]       = useState(1);
+  const [consumableSearch, setConsumableSearch] = useState("");
+  const [selectedConsumable,    setSelectedConsumable]    = useState<ConsumableId>(CONSUMABLE_RECIPES[0]?.id as ConsumableId);
+  const [consumableQty, setConsumableQty]   = useState(1);
   const [toast, setToast]           = useState<string | null>(null);
 
   // ── Broadcast tab state ───────────────────────────────────────────────────
@@ -200,6 +204,38 @@ export function DevWeatherPanel() {
     showToast(`+${gearQty} ${GEAR[gearType].name} (${GEAR[gearType].rarity})`);
   }
 
+  // Consumables aren't in saveToCloud's payload (production rule: server-authoritative
+  // via use-consumable / alchemy-craft), so dev grants do a direct DB write instead.
+  async function giveConsumable() {
+    if (!user) return;
+    const recipe = CONSUMABLE_RECIPES.find((r) => r.id === selectedConsumable);
+    if (!recipe) return;
+
+    const newConsumables = [...(state.consumables ?? [])];
+    const existing = newConsumables.find((c) => c.id === selectedConsumable);
+    if (existing) {
+      existing.quantity += consumableQty;
+    } else {
+      newConsumables.push({ id: selectedConsumable, quantity: consumableQty });
+    }
+
+    const newUpdatedAt = new Date().toISOString();
+    const { data, error } = await supabase
+      .from("game_saves")
+      .update({ consumables: newConsumables, updated_at: newUpdatedAt })
+      .eq("user_id", user.id)
+      .select("updated_at")
+      .single();
+
+    if (error || !data) {
+      showToast(`✗ ${error?.message ?? "save failed"}`);
+      return;
+    }
+
+    update({ ...state, consumables: newConsumables, serverUpdatedAt: data.updated_at as string });
+    showToast(`+${consumableQty} ${recipe.name}`);
+  }
+
   // ── Broadcast send ────────────────────────────────────────────────────────
   async function sendBroadcast() {
     if (!bcSubject.trim()) return;
@@ -237,6 +273,13 @@ export function DevWeatherPanel() {
     flowerSearch.trim() === "" ||
     f.name.toLowerCase().includes(flowerSearch.toLowerCase()) ||
     f.id.includes(flowerSearch.toLowerCase())
+  );
+
+  // ── Filtered consumable list ───────────────────────────────────────────────
+  const filteredConsumables = CONSUMABLE_RECIPES.filter((r) =>
+    consumableSearch.trim() === "" ||
+    r.name.toLowerCase().includes(consumableSearch.toLowerCase()) ||
+    r.id.includes(consumableSearch.toLowerCase())
   );
 
   // ── Render ─────────────────────────────────────────────────────────────────
@@ -698,6 +741,45 @@ export function DevWeatherPanel() {
                 className="flex-1 py-1 bg-yellow-500/20 border border-yellow-500/40 text-yellow-400 rounded-lg font-semibold hover:bg-yellow-500/30 transition-all text-center"
               >
                 Give Gear
+              </button>
+            </div>
+          </div>
+
+          {/* Consumables — vials, tonics, magnifying glass, speed boosts, pouches, etc. */}
+          <div className="bg-white/5 rounded-xl p-2.5 space-y-1.5">
+            <p className="text-yellow-400 font-semibold text-[10px] uppercase tracking-wide">Consumables</p>
+            <input
+              type="text"
+              value={consumableSearch}
+              onChange={(e) => setConsumableSearch(e.target.value)}
+              placeholder="Search consumables..."
+              className="w-full bg-black/40 border border-white/10 rounded-lg px-2 py-1 text-white text-xs placeholder:text-white/30 focus:outline-none focus:border-yellow-500/50"
+            />
+            <select
+              value={selectedConsumable}
+              onChange={(e) => setSelectedConsumable(e.target.value as ConsumableId)}
+              className="w-full bg-black/40 border border-white/10 rounded-lg px-2 py-1 text-white text-xs focus:outline-none focus:border-yellow-500/50"
+              size={5}
+            >
+              {filteredConsumables.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.emoji} {r.name} ({r.rarity})
+                </option>
+              ))}
+            </select>
+            <div className="flex gap-1.5">
+              <input
+                type="number"
+                value={consumableQty}
+                min={1}
+                onChange={(e) => setConsumableQty(Math.max(1, parseInt(e.target.value) || 1))}
+                className="w-14 bg-black/40 border border-white/10 rounded-lg px-2 py-1 text-white font-mono text-xs focus:outline-none focus:border-yellow-500/50"
+              />
+              <button
+                onClick={giveConsumable}
+                className="flex-1 py-1 bg-yellow-500/20 border border-yellow-500/40 text-yellow-400 rounded-lg font-semibold hover:bg-yellow-500/30 transition-all text-center"
+              >
+                Give Consumable
               </button>
             </div>
           </div>

--- a/src/components/PlotTile.tsx
+++ b/src/components/PlotTile.tsx
@@ -428,7 +428,7 @@ export function PlotTile({
         )}
 
         {/* Gear effect indicators — bottom-left row */}
-        {settings.plotGearIndicator && (isUnderSprinkler || sprinklerMutations.length > 0 || isUnderScarecrow || isUnderComposter || isUnderGrowLamp || isUnderFan || isUnderHarvestBell || plant.infused) && (
+        {settings.plotGearIndicator && (isUnderSprinkler || sprinklerMutations.length > 0 || isUnderScarecrow || isUnderComposter || isUnderGrowLamp || isUnderFan || isUnderHarvestBell || plant.infused || plant.revealed) && (
           <div className={`absolute left-0.5 flex leading-none ${isBloomed ? "bottom-1" : "bottom-2.5"}`}>
             {isUnderSprinkler && <span className="text-[9px]" title="Under sprinkler">💧</span>}
             {sprinklerMutations.map(({ emoji, label }, i) => (
@@ -440,6 +440,7 @@ export function PlotTile({
             {isUnderFan && <span className="text-[9px]" title="In fan range">💨</span>}
             {isUnderHarvestBell && <span className="text-[9px]" title="Auto-harvest active">🔔</span>}
             {plant.infused && <span className="text-[9px]" title="Attuned — cross-breeding active">🥢</span>}
+            {plant.revealed && <span className="text-[9px]" title="Revealed — mutation locked in">🔎</span>}
           </div>
         )}
 

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -112,6 +112,8 @@ export function PlotTooltip({
     if (c.id.startsWith("bloom_burst_") && isBloomed) return false;
     // Heirloom Charm only works on bloomed plants
     if (c.id.startsWith("heirloom_charm_") && !isBloomed) return false;
+    // Magnifying Glass: hide once the plant is already revealed
+    if (c.id.startsWith("magnifying_glass_") && plant.revealed) return false;
     return true;
   });
 
@@ -245,16 +247,27 @@ export function PlotTooltip({
           {isBloomed && (
             <p className="text-primary font-semibold">Ready to harvest!</p>
           )}
-          {isBloomed && plant.mutation && (() => {
+          {/* Mutation display — surfaces both bloomed plants and revealed (locked) plants. */}
+          {(isBloomed || plant.revealed) && plant.mutation && (() => {
             const mut = MUTATIONS[plant.mutation];
             return (
               <p className={`text-[10px] font-mono ${mut.color}`}>
-                {mut.emoji} {mut.name} · ×{mut.valueMultiplier} value
+                {plant.revealed && "🔎 "}{mut.emoji} {mut.name} · ×{mut.valueMultiplier} value
+                {plant.revealed && !isBloomed && " (locked)"}
               </p>
             );
           })()}
-          {isBloomed && plant.mutation === null && (
+          {/* Bloomed-only "No mutation" message — preserves original undefined-vs-null distinction. */}
+          {isBloomed && !plant.revealed && plant.mutation === null && (
             <p className="text-[10px] text-muted-foreground font-mono">No mutation</p>
+          )}
+          {/* Revealed-but-not-bloomed: explicit "No mutation (locked)" for null OR undefined. */}
+          {plant.revealed && !isBloomed && plant.mutation == null && (
+            <p className="text-[10px] text-muted-foreground font-mono">🔎 No mutation (locked)</p>
+          )}
+          {/* Revealed AND bloomed with no mutation (== null catches both null and undefined). */}
+          {plant.revealed && isBloomed && plant.mutation == null && (
+            <p className="text-[10px] text-muted-foreground font-mono">🔎 No mutation (locked)</p>
           )}
           {/* Active consumable flags */}
           {plant.heirloomActive && (

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -48,6 +48,9 @@ export interface PlantedFlower {
   forcedMutation?: "giant";
   /** Set by mutation-boost vials — multiplies the chance of the specified mutation during harvest */
   mutationBoost?: { mutation: string; multiplier: number };
+  /** Set by Magnifying Glass — locks in whatever mutation state the plant currently has.
+   *  Future weather/sprinkler/fan ticks skip this plant so its mutation can no longer change. */
+  revealed?: boolean;
 }
 
 export interface Plot {
@@ -1200,6 +1203,9 @@ export function tickWeatherMutations(
     row.map((plot, ci) => {
       if (!plot.plant) return plot;
 
+      // Magnifying Glass — once revealed, the plant's mutation state is locked
+      if (plot.plant.revealed) return plot;
+
       // Weather mutations only apply at bloom — the plant must be at peak to be affected
       const stage = getCurrentStage(plot.plant, now, weatherType);
       if (stage !== "bloom") return plot;
@@ -1281,6 +1287,9 @@ export function tickSprinklerMutations(
     row.map((plot, ci) => {
       if (!plot.plant) return plot;
 
+      // Magnifying Glass — once revealed, the plant's mutation state is locked
+      if (plot.plant.revealed) return plot;
+
       const stage = getCurrentStage(plot.plant, now, weatherType);
       if (stage !== "bloom") return plot;
 
@@ -1350,6 +1359,9 @@ export function tickFanMutations(
   const newGrid = state.grid.map((row, ri) =>
     row.map((plot, ci) => {
       if (!plot.plant) return plot;
+
+      // Magnifying Glass — once revealed, fans can no longer strip or apply
+      if (plot.plant.revealed) return plot;
 
       const stage = getCurrentStage(plot.plant, now, weatherType);
       if (stage !== "bloom") return plot;
@@ -2359,6 +2371,10 @@ export function applyPlantConsumable(
     updatedPlant = { ...updatedPlant, mutationBoost: { mutation: "golden",   multiplier: 5 }, mutationBlocked: undefined };
   } else if (consumableId.startsWith("rainbow_vial_")) {
     updatedPlant = { ...updatedPlant, mutationBoost: { mutation: "rainbow",  multiplier: 5 }, mutationBlocked: undefined };
+  } else if (consumableId.startsWith("magnifying_glass_")) {
+    // Lock in the plant's current mutation state — future ticks skip revealed plants.
+    if (plant.revealed) return null;
+    updatedPlant = { ...updatedPlant, revealed: true };
   }
 
   const newGrid = after.grid.map((r, ri) =>

--- a/supabase/functions/tick-offline-gardens/index.ts
+++ b/supabase/functions/tick-offline-gardens/index.ts
@@ -133,6 +133,9 @@ interface Plant {
   // Consumable flags — set by use-consumable, consumed at harvest
   mutationBlocked?: boolean;
   mutationBoost?:   { mutation: string; multiplier: number };
+  // Magnifying Glass — once true, this plant's mutation state is locked and
+  // no further weather/sprinkler/fan rolls should change it.
+  revealed?:        boolean;
 }
 interface Gear { gearType: string; placedAt: number; }
 interface Plot { id: string; plant?: Plant | null; gear?: Gear | null; }
@@ -312,6 +315,10 @@ function rollWeatherMutations(grid: Plot[][], weatherType: string, now: number):
 
   const next = grid.map(row => row.map(plot => {
     if (!plot.plant || !plot.plant.bloomedAt) return plot;
+
+    // ── Magnifying Glass guard ───────────────────────────────────────────────
+    // Once revealed, the plant's mutation state is locked across reloads.
+    if (plot.plant.revealed) return plot;
 
     // ── Purity Vial guard ────────────────────────────────────────────────────
     // mutationBlocked plants are shielded from all weather mutations.

--- a/supabase/functions/use-consumable/index.ts
+++ b/supabase/functions/use-consumable/index.ts
@@ -231,6 +231,7 @@ type PlantData = {
   mutationBlocked?: boolean;
   forcedMutation?:  string;
   mutationBoost?:   { mutation: string; multiplier: number };
+  revealed?:        boolean;
   [key: string]: unknown;
 };
 type GridCell = { id: string; plant: PlantData | null; gear?: unknown };
@@ -446,6 +447,14 @@ Deno.serve(async (req: Request) => {
           mutationBlocked: undefined,
           mutationBoost:   undefined,
         };
+
+      // ── Magnifying Glass ────────────────────────────────────────────────────
+      // Locks in whatever mutation state the plant currently has — future
+      // weather/sprinkler/fan ticks skip revealed plants. Player decides when
+      // to lock based on what's already rolled.
+      } else if (consumableId.startsWith("magnifying_glass_")) {
+        if (plant.revealed) return err("This plant is already revealed");
+        updatedPlant = { ...updatedPlant, revealed: true };
 
       // ── Mutation-boost vials (Frost, Ember, Storm, Moon, Golden, Rainbow) ───
       } else {


### PR DESCRIPTION
## Summary

Magnifying Glass now does something. Apply it to a tier-matched plot (growing or bloomed) to lock in whatever mutation state the plant currently has — future weather/sprinkler/fan rolls skip it, so the result is permanent. Strategic trade-off: lock early (safe, but maybe no mutation) vs. wait (riskier, but better odds of catching a roll).

Also adds a Consumables grant section to the dev panel Items tab so any of the ~100 consumables can be given for testing.

## Type

- `PlantedFlower.revealed?: boolean` added to client (`gameStore.ts`) and server (`use-consumable`, `tick-offline-gardens`) types. Lives in the `grid` JSONB so no migration needed; existing plants come back without the flag and behave normally.

## Skip-the-revealed guards

- Client: `tickWeatherMutations`, `tickSprinklerMutations`, `tickFanMutations` all early-return on revealed plants.
- Server: `tick-offline-gardens` offline mutation pass mirrors the same guard.

## Apply path

- `use-consumable` `apply_to_plant` gets a `magnifying_glass_*` branch — validates tier vs. plant rarity (existing tier-matching logic), refuses if already revealed, sets `plant.revealed = true`. Reuses the vial deduct-and-write pattern.
- Client `applyPlantConsumable` mirrors the branch for optimistic updates.
- No new edge function (piggybacks on the existing `apply_to_plant` action). No migration.

## UI

- `PlotTooltip` per-plot consumable filter already surfaced any tier-matched consumable, so Magnifying Glass appears alongside vials. Added a guard to hide it once revealed.
- Mutation display now renders for both bloomed and revealed plants — prefixed with 🔎 and tagged "(locked)" when revealed but not yet bloomed. Handles all three cases: revealed-with-mutation, revealed-no-mutation (covers both `null` and `undefined`), and the original bloomed-no-mutation.
- New 🔎 badge in the PlotTile bottom-left indicators row.

## Dev panel

- New "Consumables" block in the Items tab — searchable list of all ~100 entries, quantity input, Give button.
- `saveToCloud`'s payload deliberately omits `consumables` (server-authoritative in production), so the dev grant does a direct `update().eq("user_id", ...)` instead of going through `devSave`, then refreshes `serverUpdatedAt` from the response.

## Test plan

- [ ] Give yourself Magnifying Glass III (Mythic) via dev panel → it appears in inventory
- [ ] Plant a Mythic seed → tap the plot → 🔍 button appears alongside vials
- [ ] Crank Mutation Rate × 100 in dev panel → wait a few seconds → mutation rolls
- [ ] Apply magnifier → 🔎 badge appears on PlotTile, "(locked)" line shows in tooltip
- [ ] Change weather → mutation does NOT change (locked stuck)
- [ ] Apply magnifier on a freshly-planted seed (no mutation yet) → locks in "No mutation"
- [ ] Try to apply magnifier twice → second attempt fails ("already revealed")
- [ ] Hard refresh → `revealed` flag persists in grid