### PR TITLE
feat(garden-pin): Phase 5c — pinned plot consumable + downward tier match

### DIFF
--- a/src/components/PlotTile.tsx
+++ b/src/components/PlotTile.tsx
@@ -468,10 +468,19 @@ export function PlotTile({
           </div>
         )}
 
-        {/* Bloom pulse dot — top-right */}
-        {isBloomed && (
+        {/* Top-right indicator:
+            - pinned plant → 📌 (overrides the bloom pulse, since auto-harvest is shielded)
+            - bloomed unpinned → pulsing circle to draw attention to harvest-ready state */}
+        {plant.pinned ? (
+          <span
+            className="absolute -top-1 -right-1 text-sm leading-none"
+            title="Pinned — auto-harvest blocked"
+          >
+            📌
+          </span>
+        ) : isBloomed ? (
           <div className="absolute -top-1 -right-1 w-3 h-3 bg-primary rounded-full animate-pulse" />
-        )}
+        ) : null}
 
         {/* Mutation emoji — bottom-right */}
         {settings.plotMutationIndicator && isBloomed && (plant as PlantedFlower).mutation && (
@@ -480,8 +489,8 @@ export function PlotTile({
           </span>
         )}
 
-        {/* Tooltip-open indicator */}
-        {open && !isBloomed && (
+        {/* Tooltip-open indicator (suppressed when pinned — 📌 occupies the slot) */}
+        {open && !isBloomed && !plant.pinned && (
           <div className="absolute -top-1 -right-1 w-3 h-3 bg-primary/60 rounded-full" />
         )}
 

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -105,12 +105,10 @@ export function PlotTooltip({
 
   // Consumables applicable to this plant right now.
   //
-  // Tier-vs-rarity rule:
-  //   - Magnifying Glass / Garden Pin allow DOWNWARD match (a higher-rarity
-  //     consumable works on lower-rarity plants — e.g. Mythic pin on a Rare).
-  //     Floor is still tier 1 (Rare), so Common/Uncommon plants stay excluded.
-  //   - All other plant-targeting consumables (vials, Bloom Burst, Heirloom
-  //     Charm) require strict equality.
+  // Tier-vs-rarity rule: ALL plant-targeting consumables match DOWNWARD — a
+  // higher-tier consumable works on lower-rarity plants (e.g. Mythic vial on
+  // a Rare). Floor is still tier 1 (Rare), so Common/Uncommon plants stay
+  // excluded.
   const RARITY_ORDER: Record<string, number> = {
     common: 0, uncommon: 1, rare: 2, legendary: 3, mythic: 4, exalted: 5, prismatic: 6,
   };
@@ -119,11 +117,7 @@ export function PlotTooltip({
     const recipe = CONSUMABLE_RECIPE_MAP[c.id as ConsumableId];
     if (!recipe || recipe.tier === null) return false;
 
-    const allowDownward = c.id.startsWith("magnifying_glass_") || c.id.startsWith("garden_pin_");
-    const tierOk = allowDownward
-      ? (RARITY_ORDER[recipe.rarity] ?? -1) >= (RARITY_ORDER[species.rarity] ?? 999)
-      : recipe.rarity === species.rarity;
-    if (!tierOk) return false;
+    if ((RARITY_ORDER[recipe.rarity] ?? -1) < (RARITY_ORDER[species.rarity] ?? 999)) return false;
 
     // Bloom Burst only works on non-bloomed plants
     if (c.id.startsWith("bloom_burst_") && isBloomed) return false;

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -102,12 +102,28 @@ export function PlotTooltip({
     (i) => i.rarity === species.rarity && i.quantity > 0
   );
 
-  // Consumables applicable to this plant right now
+  // Consumables applicable to this plant right now.
+  //
+  // Tier-vs-rarity rule:
+  //   - Magnifying Glass / Garden Pin allow DOWNWARD match (a higher-rarity
+  //     consumable works on lower-rarity plants — e.g. Mythic pin on a Rare).
+  //     Floor is still tier 1 (Rare), so Common/Uncommon plants stay excluded.
+  //   - All other plant-targeting consumables (vials, Bloom Burst, Heirloom
+  //     Charm) require strict equality.
+  const RARITY_ORDER: Record<string, number> = {
+    common: 0, uncommon: 1, rare: 2, legendary: 3, mythic: 4, exalted: 5, prismatic: 6,
+  };
   const applicableConsumables = (state.consumables ?? []).filter((c) => {
     if (c.quantity <= 0) return false;
     const recipe = CONSUMABLE_RECIPE_MAP[c.id as ConsumableId];
     if (!recipe || recipe.tier === null) return false;
-    if (recipe.rarity !== species.rarity) return false;
+
+    const allowDownward = c.id.startsWith("magnifying_glass_") || c.id.startsWith("garden_pin_");
+    const tierOk = allowDownward
+      ? (RARITY_ORDER[recipe.rarity] ?? -1) >= (RARITY_ORDER[species.rarity] ?? 999)
+      : recipe.rarity === species.rarity;
+    if (!tierOk) return false;
+
     // Bloom Burst only works on non-bloomed plants
     if (c.id.startsWith("bloom_burst_") && isBloomed) return false;
     // Heirloom Charm only works on bloomed plants

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -7,7 +7,7 @@ import {
   removePlant,
   applyPlantConsumable,
 } from "../store/gameStore";
-import { edgeApplyFertilizer, edgeRemovePlant, edgeApplyAttunement, edgeApplyPlantConsumable } from "../lib/edgeFunctions";
+import { edgeApplyFertilizer, edgeRemovePlant, edgeApplyAttunement, edgeApplyPlantConsumable, edgeUnpinPlant } from "../lib/edgeFunctions";
 import { getFlower, RARITY_CONFIG, MUTATIONS } from "../data/flowers";
 import { FlowerTypeBadges } from "./FlowerTypeBadges";
 import { FERTILIZERS, type FertilizerType } from "../data/upgrades";
@@ -58,6 +58,7 @@ export function PlotTooltip({
   const [removing,          setRemoving]          = useState(false);
   const [applyingAttunement, setApplyingAttunement] = useState(false);
   const [applyingConsumable,setApplyingConsumable]= useState<string | null>(null);
+  const [unpinning,         setUnpinning]         = useState(false);
   const [nudge,             setNudge]             = useState(0);
   const [flipped,           setFlipped]           = useState(false);
   const tooltipRef = useRef<HTMLDivElement>(null);
@@ -147,6 +148,22 @@ export function PlotTooltip({
       // Server function not yet active or error — silently re-enable button
     } finally {
       setApplyingAttunement(false);
+    }
+  }
+
+  // Garden Pin removal — required before a pinned plant can be manually
+  // harvested. Pin is consumed (no refund of the original consumable).
+  async function handleRemovePin() {
+    if (unpinning) return;
+    setUnpinning(true);
+    try {
+      const res = await edgeUnpinPlant(row, col);
+      const cur = getState();
+      update({ ...cur, grid: res.grid, serverUpdatedAt: res.serverUpdatedAt });
+    } catch {
+      // Silent — server rejected (e.g. CAS miss); pin stays in place
+    } finally {
+      setUnpinning(false);
     }
   }
 
@@ -337,10 +354,22 @@ export function PlotTooltip({
           </div>
         )}
 
-        {/* Bloomed actions — Harvest + Attunement */}
-        {isBloomed && (
+        {/* Bloomed / pinned actions — Harvest + Remove Pin + Attunement.
+            Pinned plants surface "Remove Pin" instead of Harvest; the user must
+            unpin first to actually take the bloom (pin is consumed). Unbloomed
+            pinned plants also get the button so a misplaced pin can be undone. */}
+        {(isBloomed || plant.pinned) && (
           <div className="pt-1 border-t border-border space-y-1.5">
-            {onHarvestRequest && (
+            {plant.pinned ? (
+              <button
+                onClick={handleRemovePin}
+                disabled={unpinning}
+                title="Removes the Garden Pin (consumed). Required before harvesting."
+                className="w-full py-1.5 rounded-lg bg-amber-500/20 border border-amber-500/50 text-amber-300 text-xs font-semibold hover:bg-amber-500/30 transition-colors text-center disabled:opacity-50"
+              >
+                {unpinning ? "Removing…" : "📌 Remove Pin"}
+              </button>
+            ) : onHarvestRequest && (
               <button
                 onClick={() => { onHarvestRequest(); onClose?.(); }}
                 className="w-full py-1.5 rounded-lg bg-primary/20 border border-primary/50 text-primary text-xs font-semibold hover:bg-primary/30 transition-colors text-center"
@@ -349,21 +378,24 @@ export function PlotTooltip({
               </button>
             )}
 
-            {plant.infused ? (
-              <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
-                <span>🥢</span>
-                <span className="text-[10px] text-emerald-400 font-medium">Attuned · awaiting Cropsticks</span>
-              </div>
-            ) : matchingAttunement ? (
-              <button
-                onClick={handleApplyAttunement}
-                disabled={applyingAttunement}
-                className="w-full py-1.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-xs font-medium hover:bg-emerald-500/20 transition-colors disabled:opacity-50"
-              >
-                {applyingAttunement ? "Applying…" : `🥢 Attune ×${matchingAttunement.quantity}`}
-              </button>
-            ) : (
-              <p className="text-[10px] text-muted-foreground text-center">No matching Attunement Crystal in inventory</p>
+            {/* Attunement section — only when bloomed (it operates on bloomed plants) */}
+            {isBloomed && (
+              plant.infused ? (
+                <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
+                  <span>🥢</span>
+                  <span className="text-[10px] text-emerald-400 font-medium">Attuned · awaiting Cropsticks</span>
+                </div>
+              ) : matchingAttunement ? (
+                <button
+                  onClick={handleApplyAttunement}
+                  disabled={applyingAttunement}
+                  className="w-full py-1.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-xs font-medium hover:bg-emerald-500/20 transition-colors disabled:opacity-50"
+                >
+                  {applyingAttunement ? "Applying…" : `🥢 Attune ×${matchingAttunement.quantity}`}
+                </button>
+              ) : (
+                <p className="text-[10px] text-muted-foreground text-center">No matching Attunement Crystal in inventory</p>
+              )
             )}
           </div>
         )}

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -114,6 +114,8 @@ export function PlotTooltip({
     if (c.id.startsWith("heirloom_charm_") && !isBloomed) return false;
     // Magnifying Glass: hide once the plant is already revealed
     if (c.id.startsWith("magnifying_glass_") && plant.revealed) return false;
+    // Garden Pin: hide once the plant is already pinned
+    if (c.id.startsWith("garden_pin_") && plant.pinned) return false;
     return true;
   });
 

--- a/src/data/consumables.ts
+++ b/src/data/consumables.ts
@@ -20,6 +20,7 @@ export type ConsumableId =
   | "seed_pouch_1"     | "seed_pouch_2"     | "seed_pouch_3"     | "seed_pouch_4"     | "seed_pouch_5"
   | `seed_pouch_${"blaze"|"tide"|"grove"|"frost"|"storm"|"lunar"|"solar"|"fairy"|"shadow"|"arcane"|"stellar"|"zephyr"}_${1|2|3|4|5}`
   | "magnifying_glass_1" | "magnifying_glass_2" | "magnifying_glass_3" | "magnifying_glass_4" | "magnifying_glass_5"
+  | "garden_pin_1"       | "garden_pin_2"       | "garden_pin_3"       | "garden_pin_4"       | "garden_pin_5"
   | "verdant_rush_1"     | "verdant_rush_2"     | "verdant_rush_3"     | "verdant_rush_4"     | "verdant_rush_5"
   | "forge_haste_1"      | "forge_haste_2"      | "forge_haste_3"      | "forge_haste_4"      | "forge_haste_5"
   | "resonance_draft_1"  | "resonance_draft_2"  | "resonance_draft_3"  | "resonance_draft_4"  | "resonance_draft_5";
@@ -314,6 +315,25 @@ export const CONSUMABLE_RECIPES: ConsumableRecipe[] = [
   { id: "magnifying_glass_5", name: "Magnifying Glass V",   emoji: "🔍", tier: 5, rarity: "prismatic", category: "utility",
     description: `Reveals all details of a ${r(5)} plot — species, mutation, and exact growth progress.`,
     cost: { kind: "consumable", id: "magnifying_glass_4", quantity: 2 } },
+
+  // ── Garden Pin (I–V) — utility ───────────────────────────────────────────
+  // Pins a single plot — when bloomed, the plant is shielded from auto-harvest
+  // (Harvest Bell, Auto-Planter). Player can still manually harvest at will.
+  { id: "garden_pin_1", name: "Garden Pin I",   emoji: "📌", tier: 1, rarity: "rare",      category: "utility",
+    description: `Pins a ${r(1)} plot — its bloom won't be auto-harvested by Harvest Bells or Auto-Planters.`,
+    cost: { kind: "essence", amounts: [{ type: "arcane", amount: 3 }, { type: "fairy", amount: 3 }] } },
+  { id: "garden_pin_2", name: "Garden Pin II",  emoji: "📌", tier: 2, rarity: "legendary", category: "utility",
+    description: `Pins a ${r(2)} plot — its bloom won't be auto-harvested by Harvest Bells or Auto-Planters.`,
+    cost: { kind: "consumable", id: "garden_pin_1", quantity: 2 } },
+  { id: "garden_pin_3", name: "Garden Pin III", emoji: "📌", tier: 3, rarity: "mythic",    category: "utility",
+    description: `Pins a ${r(3)} plot — its bloom won't be auto-harvested by Harvest Bells or Auto-Planters.`,
+    cost: { kind: "consumable", id: "garden_pin_2", quantity: 2 } },
+  { id: "garden_pin_4", name: "Garden Pin IV",  emoji: "📌", tier: 4, rarity: "exalted",   category: "utility",
+    description: `Pins a ${r(4)} plot — its bloom won't be auto-harvested by Harvest Bells or Auto-Planters.`,
+    cost: { kind: "consumable", id: "garden_pin_3", quantity: 2 } },
+  { id: "garden_pin_5", name: "Garden Pin V",   emoji: "📌", tier: 5, rarity: "prismatic", category: "utility",
+    description: `Pins a ${r(5)} plot — its bloom won't be auto-harvested by Harvest Bells or Auto-Planters.`,
+    cost: { kind: "consumable", id: "garden_pin_4", quantity: 2 } },
 
   // ── Verdant Rush (I–V) — speed_boost ─────────────────────────────────────
   // Doubles growth speed for all garden plots for a limited time.

--- a/src/data/gear-recipes.ts
+++ b/src/data/gear-recipes.ts
@@ -232,14 +232,6 @@ export const GEAR_RECIPES: GearRecipe[] = [
     durationMs:     DL,
   },
 
-  // ── Garden Pin ────────────────────────────────────────────────────────────
-  {
-    outputGearType: "garden_pin",
-    ingredients:    [E("arcane", 3), E("fairy", 3)],
-    coinCost:       200,
-    durationMs:     DU,
-  },
-
   // ── Cropsticks (legendary) ────────────────────────────────────────────────
   {
     outputGearType: "cropsticks",

--- a/src/data/gear.ts
+++ b/src/data/gear.ts
@@ -34,14 +34,13 @@ export type PassiveGearType =
   | "aegis_uncommon"
   | "aegis_rare"
   | "aegis_legendary"
-  | "garden_pin"
   | "auto_planter_prismatic"
   | "cropsticks";
 
 export type GearType = SprinklerGearType | PassiveGearType;
 
 export type GearCategory  = "sprinkler_regular" | "sprinkler_mutation" | "passive";
-export type PassiveSubtype = "grow_lamp" | "scarecrow" | "composter" | "fan" | "harvest_bell" | "auto_planter" | "cropsticks" | "aegis" | "garden_pin";
+export type PassiveSubtype = "grow_lamp" | "scarecrow" | "composter" | "fan" | "harvest_bell" | "auto_planter" | "cropsticks" | "aegis";
 
 /** Which way a Fan or Aegis is pointing — set at placement time */
 export type FanDirection = "up" | "down" | "left" | "right";
@@ -578,22 +577,6 @@ export const GEAR: Record<GearType, GearDefinition> = {
     fanRange:       4,
   },
 
-  // ── Garden Pin ────────────────────────────────────────────────────────────
-  // Placed in any plot cell. Marks the plot as "pinned" — blocks manual
-  // harvests and all mutations (weather and sprinkler) until removed.
-  // Permanent — no expiry.
-
-  garden_pin: {
-    id:             "garden_pin",
-    name:           "Garden Pin",
-    description:    "Marks this plot. Blocks harvests and mutations until removed. Permanent.",
-    emoji:          "📌",
-    rarity:         "uncommon",
-    shopPrice:      0,
-    category:       "passive",
-    passiveSubtype: "garden_pin",
-  },
-
   // ── Auto-Planter ─────────────────────────────────────────────────────────
   // Automatically plants seeds from the player's inventory into empty cells
   // within a 5×5 area — works even while offline.
@@ -761,10 +744,6 @@ export function isAutoPlanter(def: GearDefinition): boolean {
 
 export function isCropsticks(def: GearDefinition): boolean {
   return def.passiveSubtype === "cropsticks";
-}
-
-export function isGardenPin(def: GearDefinition): boolean {
-  return def.passiveSubtype === "garden_pin";
 }
 
 // ── Supply shop pools ──────────────────────────────────────────────────────

--- a/src/lib/edgeFunctions.ts
+++ b/src/lib/edgeFunctions.ts
@@ -122,6 +122,18 @@ export function edgeRemovePlant(row: number, col: number) {
   return callEdge<RemovePlantResult>("remove-plant", { row, col });
 }
 
+export interface UnpinPlantResult {
+  ok:              true;
+  grid:            GameState["grid"];
+  serverUpdatedAt: string;
+}
+
+/** Strip the Garden Pin flag from a plant — required before the bloom can be
+ *  manually harvested. The pin is consumed (no refund). */
+export function edgeUnpinPlant(row: number, col: number) {
+  return callEdge<UnpinPlantResult>("unpin-plant", { row, col });
+}
+
 export function edgeBuyFlower(speciesId: string, buyAll = false) {
   return callEdge<ShopActionResult>("shop-action", {
     action: buyAll ? "buy_all" : "buy",

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -51,6 +51,9 @@ export interface PlantedFlower {
   /** Set by Magnifying Glass — locks in whatever mutation state the plant currently has.
    *  Future weather/sprinkler/fan ticks skip this plant so its mutation can no longer change. */
   revealed?: boolean;
+  /** Set by Garden Pin — when bloomed, the plant is shielded from auto-harvest
+   *  (Harvest Bell, Auto-Planter). Manual harvest still works. */
+  pinned?: boolean;
 }
 
 export interface Plot {
@@ -1418,6 +1421,8 @@ export function tickHarvestBells(
         if (ar === ri && ac === ci) continue; // never process bell's own cell
         const targetPlot = updated.grid[ar]?.[ac];
         if (!targetPlot?.plant) continue;
+        // Garden Pin shields the plant from auto-harvest
+        if (targetPlot.plant.pinned) continue;
         const stage = getCurrentStage(targetPlot.plant, now, weatherType);
         if (stage !== "bloom") continue;
         // Skip plants that bloomed less than 5 s ago — prevents same-render-tick harvesting
@@ -1458,6 +1463,8 @@ export function findHarvestBellTargets(
         if (ar === ri && ac === ci) continue;
         const targetPlot = state.grid[ar]?.[ac];
         if (!targetPlot?.plant) continue;
+        // Garden Pin shields the plant from auto-harvest
+        if (targetPlot.plant.pinned) continue;
         const stage = getCurrentStage(targetPlot.plant, now, weatherType);
         if (stage !== "bloom") continue;
         // Grace period: skip plants that bloomed < 5 s ago (avoids same-tick self-harvest)
@@ -2375,6 +2382,10 @@ export function applyPlantConsumable(
     // Lock in the plant's current mutation state — future ticks skip revealed plants.
     if (plant.revealed) return null;
     updatedPlant = { ...updatedPlant, revealed: true };
+  } else if (consumableId.startsWith("garden_pin_")) {
+    // Shield the plot from auto-harvest (Harvest Bell, Auto-Planter).
+    if (plant.pinned) return null;
+    updatedPlant = { ...updatedPlant, pinned: true };
   }
 
   const newGrid = after.grid.map((r, ri) =>

--- a/supabase/functions/craft-cancel/index.ts
+++ b/supabase/functions/craft-cancel/index.ts
@@ -55,7 +55,6 @@ const GEAR_RECIPES: GearRecipe[] = [
   { outputGearType: "aegis_uncommon",        ingredients: [E("zephyr", 5), E("shadow", 3)] },
   { outputGearType: "aegis_rare",            ingredients: [G("aegis_uncommon")] },
   { outputGearType: "aegis_legendary",       ingredients: [G("aegis_rare")] },
-  { outputGearType: "garden_pin",            ingredients: [E("arcane", 3), E("fairy", 3)] },
   { outputGearType: "cropsticks",            ingredients: [E("arcane", 4), E("stellar", 4), E("grove", 4)] },
   { outputGearType: "auto_planter_prismatic",ingredients: [G("sprinkler_prismatic", 1), G("harvest_bell_legendary", 1), E("universal", 10)] },
 ];

--- a/supabase/functions/craft-start/index.ts
+++ b/supabase/functions/craft-start/index.ts
@@ -67,7 +67,6 @@ const GEAR_RECIPES: GearRecipe[] = [
   { outputGearType: "aegis_uncommon",        ingredients: [E("zephyr", 5), E("shadow", 3)],                                                           coinCost: 500,     durationMs: DU },
   { outputGearType: "aegis_rare",            ingredients: [G("aegis_uncommon")],                                                                       coinCost: 2_000,   durationMs: DR },
   { outputGearType: "aegis_legendary",       ingredients: [G("aegis_rare")],                                                                           coinCost: 15_000,  durationMs: DL },
-  { outputGearType: "garden_pin",            ingredients: [E("arcane", 3), E("fairy", 3)],                                                            coinCost: 200,     durationMs: DU },
   { outputGearType: "cropsticks",            ingredients: [E("arcane", 4), E("stellar", 4), E("grove", 4)],                                           coinCost: 20_000,  durationMs: DL },
   { outputGearType: "auto_planter_prismatic",ingredients: [G("sprinkler_prismatic", 1), G("harvest_bell_legendary", 1), E("universal", 10)],          coinCost: 500_000, durationMs: DP },
 ];

--- a/supabase/functions/tick-offline-gardens/index.ts
+++ b/supabase/functions/tick-offline-gardens/index.ts
@@ -136,6 +136,9 @@ interface Plant {
   // Magnifying Glass — once true, this plant's mutation state is locked and
   // no further weather/sprinkler/fan rolls should change it.
   revealed?:        boolean;
+  // Garden Pin — when bloomed, plant is shielded from auto-harvest (Harvest
+  // Bell, Auto-Planter). Manual harvest still works.
+  pinned?:          boolean;
 }
 interface Gear { gearType: string; placedAt: number; }
 interface Plot { id: string; plant?: Plant | null; gear?: Gear | null; }
@@ -218,6 +221,8 @@ function runHarvestBells(save: Save, now: number): Save {
         if (!targetPlot.plant.bloomedAt || now - targetPlot.plant.bloomedAt < 5_000) continue;
         // Skip infused plants — they are reserved for Cropsticks cross-breeding
         if (targetPlot.plant.infused) continue;
+        // Garden Pin shields plants from auto-harvest (manual harvest still works)
+        if (targetPlot.plant.pinned) continue;
 
         const { speciesId, mutation } = targetPlot.plant;
         const mut = mutation ?? null;

--- a/supabase/functions/unpin-plant/index.ts
+++ b/supabase/functions/unpin-plant/index.ts
@@ -1,0 +1,107 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin":  "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function b64url(s: string): string {
+  const t = s.replace(/-/g, "+").replace(/_/g, "/");
+  return t + "=".repeat((4 - t.length % 4) % 4);
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+const err = (msg: string, status = 400) => json({ error: msg }, status);
+
+interface PlantData { pinned?: boolean; [key: string]: unknown }
+interface GridCell  { id: string; plant: PlantData | null; gear?: unknown }
+
+// ── Main handler ──────────────────────────────────────────────────────────────
+// Removes the `pinned` flag from a plant. The Garden Pin consumable was already
+// deducted at apply time; unpinning is permanent (no refund). After unpinning,
+// auto-harvest (Harvest Bell, Auto-Planter) can target the plant again.
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  try {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return err("Unauthorized", 401);
+
+    const token = authHeader.replace("Bearer ", "");
+    let userId: string;
+    try {
+      userId = JSON.parse(atob(b64url(token.split(".")[1]))).sub;
+    } catch {
+      return err("Unauthorized", 401);
+    }
+
+    const { row, col } = await req.json() as { row?: number; col?: number };
+    if (typeof row !== "number" || typeof col !== "number") {
+      return err("row and col are required");
+    }
+
+    const supabaseAdmin = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    const [authResult, saveResult] = await Promise.all([
+      supabaseAdmin.auth.getUser(token),
+      supabaseAdmin.from("game_saves").select("grid, updated_at").eq("user_id", userId).single(),
+    ]);
+
+    if (authResult.error || !authResult.data.user || authResult.data.user.id !== userId) {
+      return err("Unauthorized", 401);
+    }
+    if (saveResult.error || !saveResult.data) return err("Save not found", 404);
+
+    const save           = saveResult.data;
+    const priorUpdatedAt = save.updated_at as string;
+    const grid           = (save.grid ?? []) as GridCell[][];
+
+    const cell = grid[row]?.[col];
+    if (!cell || !cell.plant) return err("No plant at this position");
+    if (!cell.plant.pinned)   return err("This plant is not pinned");
+
+    // Strip the pinned flag from the plant — leave all other fields intact.
+    const newGrid = grid.map((r, ri) =>
+      r.map((c, ci) => {
+        if (ri !== row || ci !== col || !c.plant) return c;
+        const { pinned: _drop, ...rest } = c.plant;
+        return { ...c, plant: rest };
+      }),
+    );
+
+    const { data: ud, error: ue } = await supabaseAdmin
+      .from("game_saves")
+      .update({ grid: newGrid, updated_at: new Date().toISOString() })
+      .eq("user_id", userId)
+      .eq("updated_at", priorUpdatedAt)
+      .select("updated_at")
+      .single();
+
+    if (ue || !ud) return err("Save conflict — please retry", 409);
+
+    void supabaseAdmin.from("action_log").insert({
+      user_id: userId,
+      action:  "unpin_plant",
+      payload: { row, col },
+    });
+
+    return json({
+      ok:              true,
+      grid:            newGrid,
+      serverUpdatedAt: ud.updated_at,
+    });
+
+  } catch (e) {
+    console.error("unpin-plant error:", e);
+    return err("Internal server error", 500);
+  }
+});

--- a/supabase/functions/use-consumable/index.ts
+++ b/supabase/functions/use-consumable/index.ts
@@ -381,8 +381,24 @@ Deno.serve(async (req: Request) => {
 
       const requiredRarity = TIER_RARITIES[tier];
       if (!requiredRarity) return err("Unknown consumable tier");
-      if (rarity !== requiredRarity) {
-        return err(`This consumable targets ${requiredRarity} plants; your plant is ${rarity}`);
+
+      // Magnifying Glass and Garden Pin can be applied DOWNWARD — a higher-tier
+      // consumable works on lower-rarity plants (e.g. Mythic pin → Rare plant).
+      // Other plant-targeting consumables (vials, Bloom Burst, Heirloom Charm)
+      // remain strictly tier-matched.
+      const RARITY_ORDER: Record<string, number> = {
+        common: 0, uncommon: 1, rare: 2, legendary: 3, mythic: 4, exalted: 5, prismatic: 6,
+      };
+      const allowDownward = consumableId.startsWith("magnifying_glass_") || consumableId.startsWith("garden_pin_");
+      const tierOk = allowDownward
+        ? (RARITY_ORDER[requiredRarity] ?? -1) >= (RARITY_ORDER[rarity] ?? 999)
+        : rarity === requiredRarity;
+      if (!tierOk) {
+        return err(
+          allowDownward
+            ? `This ${requiredRarity} consumable can't reach ${rarity} plants`
+            : `This consumable targets ${requiredRarity} plants; your plant is ${rarity}`,
+        );
       }
 
       // Deduct consumable

--- a/supabase/functions/use-consumable/index.ts
+++ b/supabase/functions/use-consumable/index.ts
@@ -232,6 +232,7 @@ type PlantData = {
   forcedMutation?:  string;
   mutationBoost?:   { mutation: string; multiplier: number };
   revealed?:        boolean;
+  pinned?:          boolean;
   [key: string]: unknown;
 };
 type GridCell = { id: string; plant: PlantData | null; gear?: unknown };
@@ -455,6 +456,13 @@ Deno.serve(async (req: Request) => {
       } else if (consumableId.startsWith("magnifying_glass_")) {
         if (plant.revealed) return err("This plant is already revealed");
         updatedPlant = { ...updatedPlant, revealed: true };
+
+      // ── Garden Pin ──────────────────────────────────────────────────────────
+      // Shields the plot from auto-harvest (Harvest Bell, Auto-Planter).
+      // Manual harvest still works. Permanent for the life of the plant.
+      } else if (consumableId.startsWith("garden_pin_")) {
+        if (plant.pinned) return err("This plant is already pinned");
+        updatedPlant = { ...updatedPlant, pinned: true };
 
       // ── Mutation-boost vials (Frost, Ember, Storm, Moon, Golden, Rainbow) ───
       } else {

--- a/supabase/functions/use-consumable/index.ts
+++ b/supabase/functions/use-consumable/index.ts
@@ -382,23 +382,14 @@ Deno.serve(async (req: Request) => {
       const requiredRarity = TIER_RARITIES[tier];
       if (!requiredRarity) return err("Unknown consumable tier");
 
-      // Magnifying Glass and Garden Pin can be applied DOWNWARD — a higher-tier
-      // consumable works on lower-rarity plants (e.g. Mythic pin → Rare plant).
-      // Other plant-targeting consumables (vials, Bloom Burst, Heirloom Charm)
-      // remain strictly tier-matched.
+      // All plant-targeting consumables match DOWNWARD — a higher-tier consumable
+      // works on lower-rarity plants (e.g. Mythic vial → Rare plant). Tier 1
+      // (Rare) is still the floor, so Common/Uncommon plants stay excluded.
       const RARITY_ORDER: Record<string, number> = {
         common: 0, uncommon: 1, rare: 2, legendary: 3, mythic: 4, exalted: 5, prismatic: 6,
       };
-      const allowDownward = consumableId.startsWith("magnifying_glass_") || consumableId.startsWith("garden_pin_");
-      const tierOk = allowDownward
-        ? (RARITY_ORDER[requiredRarity] ?? -1) >= (RARITY_ORDER[rarity] ?? 999)
-        : rarity === requiredRarity;
-      if (!tierOk) {
-        return err(
-          allowDownward
-            ? `This ${requiredRarity} consumable can't reach ${rarity} plants`
-            : `This consumable targets ${requiredRarity} plants; your plant is ${rarity}`,
-        );
+      if ((RARITY_ORDER[requiredRarity] ?? -1) < (RARITY_ORDER[rarity] ?? 999)) {
+        return err(`This ${requiredRarity} consumable can't reach ${rarity} plants`);
       }
 
       // Deduct consumable


### PR DESCRIPTION
## Summary

Garden Pin moves from gear → plot-targeted consumable. Apply it to a tier-matched plot to shield the plant from auto-harvest (Harvest Bell, Auto-Planter); manual harvest still works after explicitly removing the pin. Also relaxes the tier-vs-rarity rule for *all* plant-targeting consumables to match downward.

## Garden Pin (Phase 5c)

- Removed `garden_pin` from `GearType` union, `GEAR` catalog, `GEAR_RECIPES`, and the mirrored arrays in `craft-start` + `craft-cancel`.
- Added `garden_pin_1..5` to `ConsumableId` and `CONSUMABLE_RECIPES` (Rare → Prismatic, vial-style cost ladder).
- `PlantedFlower.pinned?: boolean` added to client + both server `PlantData` types.
- `use-consumable` `apply_to_plant` gains a `garden_pin_*` branch; client `applyPlantConsumable` mirrors it.
- `tickHarvestBells` + `findHarvestBellTargets` skip pinned plants. `tick-offline-gardens` server tick mirrors the guard. Manual `harvestPlant` deliberately not guarded.
- PlotTile top-right "ready" pulse is replaced by 📌 when pinned.

## Remove Pin

- New `unpin-plant` edge function — strips `pinned` from a plant after auth + grid validation. Pin is consumed (no refund of the original consumable).
- New `edgeUnpinPlant` caller.
- `PlotTooltip` swaps the **Harvest** button for **📌 Remove Pin** when the plant is pinned. Surfaces the button on unbloomed pinned plants too so misplaced pins can be undone.

## Downward tier match (all plant-targeted consumables)

- Server `apply_to_plant`: replaced strict `rarity !== requiredRarity` with `RARITY_ORDER[recipe.rarity] >= RARITY_ORDER[plant.rarity]`. A Mythic Frost Vial now works on Mythic, Legendary, or Rare plants.
- Client `PlotTooltip` filter mirrors the same rule so the UI never offers something the server would reject.
- Tier I (Rare) is still the floor — Common/Uncommon plants stay excluded.

## Test plan

- [ ] Give yourself Garden Pin III (Mythic) → it appears in Inventory consumables tab
- [ ] Plant a Mythic seed → tap plot → 📌 button appears in tooltip
- [ ] Apply pin → 📌 badge replaces top-right pulse on PlotTile
- [ ] Wait for bloom + active Harvest Bell → bell skips the pinned plant
- [ ] Tap pinned bloomed plant → "📌 Remove Pin" shows instead of "Harvest"
- [ ] Click Remove Pin → pin clears, "Harvest" button reappears
- [ ] With Mythic Garden Pin, try applying to a Rare plant → works (downward match)
- [ ] Try applying to a Common plant → not offered (tier I floor)
- [ ] Apply Mythic Frost Vial to a Rare plant → works