### PR TITLE
feat: Phase 6 — Scarecrow rework + Aegis implementation

### DIFF
--- a/src/components/Garden.tsx
+++ b/src/components/Garden.tsx
@@ -13,6 +13,7 @@ import {
   assignBloomMutations,
   tickWeatherMutations,
   tickSprinklerMutations,
+  tickScarecrowStrip,
   tickFanMutations,
   findHarvestBellTargets,
   findAutoPlantTargets,
@@ -57,6 +58,7 @@ export function Garden({ onHarvestPopup }: { onHarvestPopup: (speciesId: string,
     let next = stampStageTransitions(latest, now, weather);
     next = tickWeatherMutations(next, weather);
     next = tickSprinklerMutations(next, weather);
+    next = tickScarecrowStrip(next, weather);
     next = tickFanMutations(next, weather);
     next = assignBloomMutations(next, weather);
     if (next !== latest) update(next);

--- a/src/components/Inventory.tsx
+++ b/src/components/Inventory.tsx
@@ -372,6 +372,7 @@ function EmptyTab({ emoji, message, hint }: { emoji: string; message: string; hi
 
 function GearInventoryRow({ item }: { item: GearInventoryItem }) {
   const def    = GEAR[item.gearType];
+  if (!def) return null; // orphan from a removed gear type (cleaned up on next applyOfflineTick)
   const rarity = RARITY_CONFIG[def.rarity];
   return (
     <div className={`flex items-center gap-4 bg-card/60 border rounded-xl px-4 py-3 ${def.rarity === "prismatic" ? "rainbow-border rainbow-glow" : `${rarity?.glow ?? ""} border-border`}`}>

--- a/src/components/SeedPicker.tsx
+++ b/src/components/SeedPicker.tsx
@@ -203,6 +203,7 @@ export function SeedPicker({ onSelect, onBloomSelect, onGearSelect, onClose }: P
           gear.length > 0 ? (
             gear.map((item) => {
               const def    = GEAR[item.gearType];
+              if (!def) return null; // orphan from a removed gear type (cleaned up on next applyOfflineTick)
               const rarity = RARITY_CONFIG[def.rarity];
               return (
                 <button

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -536,7 +536,10 @@ export function applyOfflineTick(
     supplySlots:          save.supplySlots          ?? DEFAULT_SUPPLY_SLOTS,
     supplyShop:           save.supplyShop           ?? generateSupplyShop(save.supplySlots ?? DEFAULT_SUPPLY_SLOTS),
     lastSupplyReset:      save.lastSupplyReset       ?? now2,
-    gearInventory:        save.gearInventory         ?? [],
+    // Filter out gear types that no longer exist in the GEAR catalog (e.g. orphan
+    // `garden_pin` from before it was migrated to a consumable). Keeps renderers
+    // safe from `GEAR[type].rarity` crashes on unknown ids.
+    gearInventory:        (save.gearInventory ?? []).filter((g) => GEAR[g.gearType] !== undefined),
     essences:             save.essences              ?? [],
     discoveredRecipes:    save.discoveredRecipes     ?? [],
     infusers:             save.infusers              ?? [],

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -14,7 +14,7 @@ import {
 import {
   GEAR, isGearExpired, getGearAffectingCell, getAffectedCells,
   isRegularSprinkler, isMutationSprinkler,
-  isScarecrow, isGrowLamp, isComposter, isFan, isHarvestBell, isAutoPlanter,
+  isScarecrow, isAegis, isGrowLamp, isComposter, isFan, isHarvestBell, isAutoPlanter,
   rollComposterFertilizer,
   SUPPLY_POOLS, SUPPLY_RARITY_WEIGHTS, isRarityUnlocked,
   type GearType, type PlacedGear, type GearInventoryItem, type FanDirection,
@@ -1216,10 +1216,12 @@ export function tickWeatherMutations(
       // Purity Vial blocks all weather mutations
       if (plot.plant.mutationBlocked) return plot;
 
-      // Scarecrow fully blocks all weather mutations on covered plants
-      const scarecrowSources = getGearAffectingCell(state.grid, ri, ci, now);
-      const hasScarecrow = scarecrowSources.some(({ def }) => isScarecrow(def));
-      if (hasScarecrow) return plot;
+      // Scarecrow OR Aegis fully blocks weather mutation rolls on covered plants.
+      // Both are weather shields; the difference is gear-mutation handling
+      // (Scarecrow blocks gear mutations too, Aegis does not — see tickSprinklerMutations).
+      const shieldSources = getGearAffectingCell(state.grid, ri, ci, now);
+      const hasShield = shieldSources.some(({ def }) => isScarecrow(def) || isAegis(def));
+      if (hasShield) return plot;
 
       const m = _devMutationMultiplier;
       const boostFor = (mt: string): number =>
@@ -1300,6 +1302,11 @@ export function tickSprinklerMutations(
       if (plot.plant.mutationBlocked) return plot;
 
       const sources = getGearAffectingCell(state.grid, ri, ci, now);
+
+      // Scarecrow blocks gear-based mutations too (sprinklers, mutation sprinklers,
+      // generator wet→shocked). Aegis is weather-only and does NOT block here.
+      if (sources.some(({ def }) => isScarecrow(def))) return plot;
+
       const boostFor = (mt: string): number =>
         plot.plant!.mutationBoost?.mutation === mt
           ? (plot.plant!.mutationBoost!.multiplier ?? 1)
@@ -1345,6 +1352,55 @@ export function tickSprinklerMutations(
 
       return plot;
     })
+  );
+
+  return changed ? { ...state, grid: newGrid } : state;
+}
+
+/**
+ * Called every tick. For each bloomed plant covered by an active Scarecrow,
+ * rolls the highest covering Scarecrow's `mutationStripChancePerTick`. On hit,
+ * sets `plant.mutation = null` (matches Fan strip convention — Giant tried-and-failed
+ * marker, weather can no longer assign).
+ *
+ * Skipped when:
+ *   - plant has Magnifying Glass reveal lock
+ *   - plant is not bloomed
+ *   - plant has no string mutation (nothing to strip)
+ *   - plant has no covering Scarecrow
+ */
+export function tickScarecrowStrip(
+  state: GameState,
+  weatherType: WeatherType = "clear",
+): GameState {
+  const now   = Date.now();
+  let changed = false;
+
+  const newGrid = state.grid.map((row, ri) =>
+    row.map((plot, ci) => {
+      if (!plot.plant) return plot;
+      if (plot.plant.revealed) return plot;
+      if (typeof plot.plant.mutation !== "string") return plot;
+
+      const stage = getCurrentStage(plot.plant, now, weatherType);
+      if (stage !== "bloom") return plot;
+
+      // Pick the strongest scarecrow covering this cell (higher-tier scarecrow wins)
+      const sources = getGearAffectingCell(state.grid, ri, ci, now);
+      let bestChance = 0;
+      for (const { def } of sources) {
+        if (!isScarecrow(def)) continue;
+        const c = def.mutationStripChancePerTick ?? 0;
+        if (c > bestChance) bestChance = c;
+      }
+      if (bestChance <= 0) return plot;
+
+      if (Math.random() < Math.min(1, bestChance)) {
+        changed = true;
+        return { ...plot, plant: { ...plot.plant, mutation: null } };
+      }
+      return plot;
+    }),
   );
 
   return changed ? { ...state, grid: newGrid } : state;

--- a/supabase/functions/tick-offline-gardens/index.ts
+++ b/supabase/functions/tick-offline-gardens/index.ts
@@ -111,11 +111,28 @@ const OFFSETS_DIAMOND: [number, number][] = [
 ];
 
 // ── Gear definitions ───────────────────────────────────────────────────────
-interface GearDef { subtype: "harvest_bell" | "auto_planter"; offsets: [number, number][]; durationMs: number; }
+interface GearDef {
+  subtype: "harvest_bell" | "auto_planter" | "scarecrow" | "aegis";
+  /** Radius offsets for radial gear (harvest bell, auto-planter, scarecrow). */
+  offsets?: [number, number][];
+  /** Line-of-sight cell count for directional gear (aegis). */
+  fanRange?: number;
+  durationMs: number;
+  /** Scarecrow only — cumulative strip chance over a 1-hour window. */
+  scarecrowStripPerHour?: number;
+}
 const GEAR_DEFS: Record<string, GearDef> = {
   harvest_bell_rare:      { subtype: "harvest_bell", offsets: OFFSETS_CROSS,   durationMs:  4 * 60 * 60 * 1_000 },
-  harvest_bell_legendary: { subtype: "harvest_bell", offsets: OFFSETS_3X3,    durationMs:  8 * 60 * 60 * 1_000 },
+  harvest_bell_legendary: { subtype: "harvest_bell", offsets: OFFSETS_3X3,     durationMs:  8 * 60 * 60 * 1_000 },
   auto_planter_prismatic: { subtype: "auto_planter", offsets: OFFSETS_DIAMOND, durationMs: 12 * 60 * 60 * 1_000 },
+  // Scarecrow — blocks weather AND gear mutations within radius, plus strip chance
+  scarecrow_rare:         { subtype: "scarecrow", offsets: OFFSETS_3X3,     durationMs:  4 * 60 * 60 * 1_000, scarecrowStripPerHour: 0.15 },
+  scarecrow_legendary:    { subtype: "scarecrow", offsets: OFFSETS_3X3,     durationMs:  8 * 60 * 60 * 1_000, scarecrowStripPerHour: 0.25 },
+  scarecrow_mythic:       { subtype: "scarecrow", offsets: OFFSETS_DIAMOND, durationMs: 12 * 60 * 60 * 1_000, scarecrowStripPerHour: 0.40 },
+  // Aegis — directional, blocks weather mutations only (gear mutations still apply)
+  aegis_uncommon:         { subtype: "aegis", fanRange: 2, durationMs: 2 * 60 * 60 * 1_000 },
+  aegis_rare:             { subtype: "aegis", fanRange: 3, durationMs: 4 * 60 * 60 * 1_000 },
+  aegis_legendary:        { subtype: "aegis", fanRange: 4, durationMs: 8 * 60 * 60 * 1_000 },
 };
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -140,7 +157,7 @@ interface Plant {
   // Bell, Auto-Planter). Manual harvest still works.
   pinned?:          boolean;
 }
-interface Gear { gearType: string; placedAt: number; }
+interface Gear { gearType: string; placedAt: number; direction?: "up" | "down" | "left" | "right"; }
 interface Plot { id: string; plant?: Plant | null; gear?: Gear | null; }
 interface InvItem { speciesId: string; quantity: number; isSeed: boolean; mutation?: string | null; }
 interface Save {
@@ -180,12 +197,95 @@ function isExpired(gear: Gear, now: number): boolean {
   return !def || now >= gear.placedAt + def.durationMs;
 }
 
-function affectedCells(gearType: string, ri: number, ci: number, rows: number, cols: number): [number, number][] {
+function affectedCells(
+  gearType: string,
+  ri: number,
+  ci: number,
+  rows: number,
+  cols: number,
+  direction?: "up" | "down" | "left" | "right",
+): [number, number][] {
   const def = GEAR_DEFS[gearType];
   if (!def) return [];
+
+  // Directional gear (Aegis): line of cells in chosen direction
+  if (def.fanRange && direction) {
+    const offsets: [number, number][] = [];
+    for (let i = 1; i <= def.fanRange; i++) {
+      if (direction === "up")    offsets.push([-i,  0]);
+      if (direction === "down")  offsets.push([ i,  0]);
+      if (direction === "left")  offsets.push([ 0, -i]);
+      if (direction === "right") offsets.push([ 0,  i]);
+    }
+    return offsets
+      .map(([dr, dc]): [number, number] => [ri + dr, ci + dc])
+      .filter(([r, c]) => r >= 0 && r < rows && c >= 0 && c < cols);
+  }
+
+  // Radial gear (harvest bell, auto-planter, scarecrow)
+  if (!def.offsets) return [];
   return def.offsets
     .map(([dr, dc]): [number, number] => [ri + dr, ci + dc])
     .filter(([r, c]) => r >= 0 && r < rows && c >= 0 && c < cols);
+}
+
+// ── Mutation shield coverage ────────────────────────────────────────────────
+// Builds a per-cell map of mutation-shield coverage in one pass so the weather
+// + strip pass can do O(1) lookups instead of re-scanning gear per cell.
+//   - hasShield: true if any unexpired Scarecrow OR Aegis covers this cell
+//   - stripPerHour: max scarecrowStripPerHour from any covering Scarecrow
+interface CoverageEntry { hasShield: boolean; stripPerHour: number }
+function buildShieldCoverage(grid: Plot[][], now: number): Map<string, CoverageEntry> {
+  const rows = grid.length;
+  const cols = grid[0]?.length ?? 0;
+  const map  = new Map<string, CoverageEntry>();
+
+  for (let ri = 0; ri < rows; ri++) {
+    for (let ci = 0; ci < cols; ci++) {
+      const gear = grid[ri][ci]?.gear;
+      if (!gear) continue;
+      const def = GEAR_DEFS[gear.gearType];
+      if (!def || isExpired(gear, now)) continue;
+      if (def.subtype !== "scarecrow" && def.subtype !== "aegis") continue;
+
+      for (const [ar, ac] of affectedCells(gear.gearType, ri, ci, rows, cols, gear.direction)) {
+        const key = `${ar},${ac}`;
+        const cur = map.get(key) ?? { hasShield: false, stripPerHour: 0 };
+        cur.hasShield = true;
+        if (def.subtype === "scarecrow" && (def.scarecrowStripPerHour ?? 0) > cur.stripPerHour) {
+          cur.stripPerHour = def.scarecrowStripPerHour ?? 0;
+        }
+        map.set(key, cur);
+      }
+    }
+  }
+  return map;
+}
+
+// ── Scarecrow strip ────────────────────────────────────────────────────────
+// Per cron run, for each bloomed plant under a Scarecrow with an existing
+// string mutation, rolls the converted-to-per-minute strip chance. On hit
+// sets `mutation = null` (matches client convention; Giant-tried marker).
+function rollScarecrowStrip(grid: Plot[][], coverage: Map<string, CoverageEntry>, now: number): { grid: Plot[][]; changed: boolean } {
+  let changed = false;
+  const next = grid.map((row, ri) => row.map((plot, ci) => {
+    if (!plot.plant || !plot.plant.bloomedAt) return plot;
+    if (plot.plant.revealed) return plot;
+    if (typeof plot.plant.mutation !== "string") return plot;
+
+    const cov = coverage.get(`${ri},${ci}`);
+    if (!cov || cov.stripPerHour <= 0) return plot;
+
+    // Per-cron-run probability: cumulative perHour distributed evenly across 60 minutes.
+    // Cron runs ~per minute, so apply 1 minute's worth of strip chance per run.
+    const perMin = 1 - Math.pow(1 - cov.stripPerHour, 1 / 60);
+    if (Math.random() < perMin) {
+      changed = true;
+      return { ...plot, plant: { ...plot.plant, mutation: null } };
+    }
+    return plot;
+  }));
+  return { grid: changed ? next : grid, changed };
 }
 
 // ── Stamp bloomedAt ────────────────────────────────────────────────────────
@@ -308,9 +408,13 @@ function runAutoPlanter(save: Save, now: number): Save {
 // ── Weather mutations ──────────────────────────────────────────────────────
 // Rolls weather-based mutations on all bloomed plants (same logic as
 // tickWeatherMutations in gameStore.ts, but scaled to per-minute probability).
-// Scarecrow protection is not applied here (server has no gear-coverage lookup);
-// the worst case is an offline player gets a mutation they'd have been protected from.
-function rollWeatherMutations(grid: Plot[][], weatherType: string, now: number): { grid: Plot[][]; changed: boolean } {
+// Plants under a Scarecrow OR Aegis are skipped (both block weather mutations).
+function rollWeatherMutations(
+  grid: Plot[][],
+  weatherType: string,
+  now: number,
+  coverage: Map<string, CoverageEntry>,
+): { grid: Plot[][]; changed: boolean } {
   if (!weatherType || weatherType === "clear") return { grid, changed: false };
 
   const mutType   = WEATHER_MUTATION_TYPE[weatherType];
@@ -318,7 +422,7 @@ function rollWeatherMutations(grid: Plot[][], weatherType: string, now: number):
   const night     = isNightUTC(now);
   let changed     = false;
 
-  const next = grid.map(row => row.map(plot => {
+  const next = grid.map((row, ri) => row.map((plot, ci) => {
     if (!plot.plant || !plot.plant.bloomedAt) return plot;
 
     // ── Magnifying Glass guard ───────────────────────────────────────────────
@@ -329,6 +433,9 @@ function rollWeatherMutations(grid: Plot[][], weatherType: string, now: number):
     // mutationBlocked plants are shielded from all weather mutations.
     // The flag is consumed at harvest time, not here.
     if (plot.plant.mutationBlocked) return plot;
+
+    // ── Scarecrow / Aegis shield ─────────────────────────────────────────────
+    if (coverage.get(`${ri},${ci}`)?.hasShield) return plot;
 
     // Helper: look up any active mutation boost for a given mutation type.
     const boostFor = (mt: string): number =>
@@ -783,9 +890,16 @@ Deno.serve(async (req: Request) => {
       const { grid: stamped, changed: stampChanged } = stampBloomed(original.grid, now, weatherMult);
       let sim = stampChanged ? { ...original, grid: stamped } : original;
 
-      // 2. Roll weather mutations on bloomed plants
-      const { grid: mutGrid, changed: mutChanged } = rollWeatherMutations(sim.grid, weatherType, now);
+      // 2a. Build mutation-shield coverage once per garden (Scarecrow + Aegis)
+      const shieldCoverage = buildShieldCoverage(sim.grid, now);
+
+      // 2b. Roll weather mutations on bloomed plants (skipping shielded cells)
+      const { grid: mutGrid, changed: mutChanged } = rollWeatherMutations(sim.grid, weatherType, now, shieldCoverage);
       if (mutChanged) sim = { ...sim, grid: mutGrid };
+
+      // 2c. Scarecrow strip — chance to remove existing mutations from covered plants
+      const { grid: stripGrid, changed: stripChanged } = rollScarecrowStrip(sim.grid, shieldCoverage, now);
+      if (stripChanged) sim = { ...sim, grid: stripGrid };
 
       // 3. Harvest bell
       sim = runHarvestBells(sim, now);


### PR DESCRIPTION
## Summary

Two defensive gears get real behavior. Closes Phase 6 of the Crafting & Attunement Update.

- **Scarecrow** now blocks weather **and** gear mutations within its 3×3 radius (or diamond for Mythic), and rolls a per-tick chance to *strip* existing mutations off covered plants. Kaleidoscope/Lightning/Frost sprinklers no longer reach plants under a Scarecrow.
- **Aegis** now actually does something — blocks weather mutations along its directional `fanRange`. Does **not** block gear mutations, so a Kaleidoscope still works under an Aegis. The lighter, more selective shield.

## Client (`gameStore.ts`, `Garden.tsx`)

- `tickSprinklerMutations` short-circuits for plants under any unexpired Scarecrow. Aegis is intentionally omitted.
- `tickWeatherMutations` treats Scarecrow OR Aegis as a "shield" for weather rolls. Aegis uses `fanRange` directional coverage via the existing `getAffectedCells` helper.
- New `tickScarecrowStrip` — per tick, for each bloomed plant covered by a Scarecrow with an existing string mutation, rolls the highest covering Scarecrow's `mutationStripChancePerTick`. On hit, `mutation = null` (matches Fan strip convention). Wired into the Garden mutation tick between `tickSprinklerMutations` and `tickFanMutations`.

## Server (`tick-offline-gardens`)

Closes the audit gap (`// Scarecrow protection is not applied here…`).

- `GEAR_DEFS` extended with `scarecrow_*` (radial + `scarecrowStripPerHour`) and `aegis_*` (directional via `fanRange`).
- `affectedCells` now handles directional gear (line of cells in `direction`).
- `Gear` interface gained `direction?` so Aegis placements survive parsing.
- New `buildShieldCoverage` builds an O(grid) `Map<"r,c", { hasShield, stripPerHour }>` once per garden.
- `rollWeatherMutations` consults the coverage map and skips shielded cells.
- New `rollScarecrowStrip` runs each cron pass: converts `scarecrowStripPerHour` → per-minute probability, rolls against existing string mutations.
- Orchestration: build coverage → weather pass → strip pass → harvest bell → auto-planter → cropsticks.
- Fast-path skip already covers scarecrow/aegis-only gardens since `GEAR_DEFS` now contains them.

## Why tick-only (no harvest hook)

Matches the existing per-tick mutation system (sprinklers, fans, weather). Probability accumulates naturally over the plant's bloom life; players already model "more time covered = more chances." A harvest hook would create timing weirdness (mutation vanishing at the moment of harvest) and hide the gear's effect from observation. Strategic lever stays meaningful — letting a plant sit longer = more strip rolls.

## Bonus fix: orphan gear cleanup

Caught a regression from the Phase 5c gear → consumable migration: existing `garden_pin` entries in `gearInventory` were crashing `SeedPicker` and the Inventory Supplies tab when reading `GEAR[type].rarity` on a now-undefined entry.

- Defensive `if (!def) return null` guards in `SeedPicker.tsx` and `Inventory.tsx` `GearInventoryRow` so the current session stops crashing immediately.
- `applyOfflineTick` filters `gearInventory` through `GEAR[type] !== undefined` so the orphan gets dropped permanently on next load and won't be written back by `saveToCloud`.

## Test plan

- [ ] Plant a flower under a Mythic Scarecrow → start a Tornado → flower does NOT get Windstruck
- [ ] Drop a Kaleidoscope sprinkler next to the Scarecrow-covered plant → no Rainbow mutation rolls
- [ ] Manually mutate a covered plant (vial), wait through bloom → mutation eventually strips to "no mutation"
- [ ] Place an Aegis pointing at a plant → start Rain → plant does NOT get Wet
- [ ] Drop a Kaleidoscope on the Aegis-covered plant → Rainbow mutation **does** roll (Aegis doesn't block gear)
- [ ] Crank Mutation Rate × 50 in dev panel to compress test cycles
- [ ] Hard refresh / wait for offline tick → strip + shield logic also fires server-side
- [ ] If you have an orphan `garden_pin` in gearInventory: SeedPicker gear tab no longer crashes; entry disappears after a reload