### PR TITLE
release: v2.3.2 — bug fixes & balance

### DIFF
--- a/.github/QA_CHECKLIST.md
+++ b/.github/QA_CHECKLIST.md
@@ -347,6 +347,20 @@ A stale server response was clobbering the client's freshly-restocked shop list,
 
 ---
 
+## W. v2.3.2 — Balance Scale Rework (#181)
+
+Range is now fixed at 1 cell each side for all tiers. Boost/slow values increased per tier: Scale I 4×/0.5×, Scale II 6×/0.33×, Scale III 8×/0.25×.
+
+| # | Action | Expected |
+|---|--------|----------|
+| W1 | Place a **Balance Scale I** with one plant to its left and one to its right. Watch growth rates. | Boosted side grows **4×** faster than base; slowed side grows at **0.5×** base speed |
+| W2 | Wait for the hour to flip (or use dev panel to advance time). | The boost and slow **swap sides** |
+| W3 | Place a **Balance Scale II** and compare growth rates to Scale I. | Boosted side visibly faster (**6×**); slowed side more penalized (**0.33×**) than Scale I |
+| W4 | Place a **Balance Scale III** and compare. | Boosted side at **8×**; slowed side at **0.25×** |
+| W5 | Check gear tooltip descriptions for all three tiers. | Each description shows the correct boost and slow values for that tier |
+
+---
+
 ## Automated Gates (CI — must pass before merge)
 
 ```

--- a/.github/QA_CHECKLIST.md
+++ b/.github/QA_CHECKLIST.md
@@ -297,6 +297,56 @@ Expired listings are now delivered via the mailbox instead of silently patching 
 
 ---
 
+## S. v2.3.2 — Harvest v2.3.1 Flowers (#175)
+
+`FLOWER_GROWTH_TIMES` in the harvest edge function was missing all 38 v2.3.1 species, causing a 400 "Unknown species" error.
+
+| # | Action | Expected |
+|---|--------|----------|
+| S1 | Harvest any v2.3.1 flower (e.g. **Galebloom**, **Infernopetal**, **Cloudveil**) manually or via bell | Harvest succeeds; bloom added to inventory; **no** "Unknown species" 400 in console |
+| S2 | Harvest a mutated v2.3.1 flower (e.g. Golden Galebloom) | Harvest succeeds with the correct mutation applied to the inventory bloom |
+| S3 | DevTools → Network → `harvest` response for a v2.3.1 flower | Response is `{ ok: true }` — no error body |
+
+---
+
+## T. v2.3.2 — Composter Offline Tick (#158)
+
+Composter logic was previously client-side only. It now also runs in `tick-offline-gardens`.
+
+| # | Action | Expected |
+|---|--------|----------|
+| T1 | Place a Composter next to several seeds. Navigate away for 30+ min. Return. | Some of the plots that bloomed while away have fertilizer applied (check plot tooltips) |
+| T2 | Place a Composter I (Uncommon, 3×3 range) next to a bloom that blooms offline. Return. | Fertilizer roll occurred; rarity matches Uncommon tier (Common/Uncommon fertilizers) |
+| T3 | Place a Composter III (Legendary, Diamond range) offline. | Range covers expected diamond-shaped cells; fertilizer is applied within range |
+| T4 | Place a Composter with its `maxStorage` already full (10 charges). Navigate away. | No additional fertilizer piles up beyond the storage cap after plants bloom offline |
+
+---
+
+## U. v2.3.2 — Plot Tooltip Consumable Filter (#177 / #173)
+
+Speed boosts (Forge Haste) and seed pouches should never appear in the per-plot consumable picker.
+
+| # | Action | Expected |
+|---|--------|----------|
+| U1 | Open a plot tooltip (growing or bloomed plant). Have **Forge Haste** consumables in inventory. | Forge Haste does **not** appear in the consumable list |
+| U2 | Same tooltip with any **Seed Pouch** in inventory. | Seed Pouch does **not** appear |
+| U3 | Open the tooltip with Frost Vials, Fertilizer, etc. in inventory. | Those consumables **do** appear (filter only removes speed boosts and seed pouches) |
+| U4 | Tooltip with many consumables (10+) visible. | Tooltip scrolls vertically; bottom items are accessible; tooltip does not extend off-screen |
+
+---
+
+## V. v2.3.2 — Shop Restock Flicker (#172)
+
+A stale server response was clobbering the client's freshly-restocked shop list, causing a visible flicker back to the old items.
+
+| # | Action | Expected |
+|---|--------|----------|
+| V1 | Wait for the seed shop to restock (or use the dev panel to force a restock). | Shop updates to new items **without** briefly showing the old shop list |
+| V2 | Wait for the supply shop to restock. | Supply shop updates cleanly — **no flicker** back to the pre-restock gear/consumable list |
+| V3 | Throttle to Slow 4G. Trigger a shop restock. Watch DevTools Network. | Even with slow responses arriving after the client reset, the new shop list holds |
+
+---
+
 ## Automated Gates (CI — must pass before merge)
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [v2.3.2] — 2026-05-02 — Bug Fixes & Balance
+
+### Changed
+- **Balance Scale reworked** — range fixed to 1 cell each side for all tiers; boost and slow values now scale per tier: Scale I 4×/0.5× (avg 2.25×), Scale II 6×/0.33× (avg 3.165×), Scale III 8×/0.25× (avg 4.125×)
+- **Shop seed prices display cleaner** — prices are now floored to 2 significant figures (e.g. 1,234 → 1,200)
+- **Scarecrow description corrected** — now correctly says "Blocks all mutations" (it has always blocked gear mutations too, not just weather)
+- **Fan description corrected** — effect rate now correctly reads "each hour" instead of "each minute"
+- **Garden Pin description corrected** — now references Lawn Mowers instead of Auto-Planters
+
+### Fixed
+- **Harvesting v2.3.1 flowers no longer fails** — harvest edge function was missing all 38 v2.3.1 species, returning "Unknown species" 400 errors on every harvest
+- **Marketplace price history shows the correct mutated price** — listing base_value now includes the mutation multiplier so the chart reflects the actual listed price
+- **Composter now generates fertilizer during offline ticks** — composter logic was client-side only; it now also runs in the offline cron processor
+- **Plot tooltip no longer shows Forge Haste or Seed Pouches** — speed boosts and seed pouches don't target individual plots and are now excluded from the per-plot consumable picker
+- **Plot tooltip scrolls when many consumables are present** — tooltip no longer extends off-screen on mobile with large consumable inventories
+- **Shop no longer flickers after restock** — stale server responses arriving after a client-side shop reset no longer overwrite the fresh shop list
+
+---
+
 ## [v2.3.1] — 2026-05-01 — Flower Expansion & Fan Fix
 
 ### Added

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -138,9 +138,8 @@ export function PlotTooltip({
     if (c.quantity <= 0) return false;
     const recipe = CONSUMABLE_RECIPE_MAP[c.id as ConsumableId];
     if (!recipe) return false;
-    // Speed boosts (Forge Haste, Verdant Rush, Resonance Draft) are activated
-    // globally from the inventory — they don't target individual plots.
-    if (recipe.category === "speed_boost") return false;
+    // Speed boosts and seed pouches don't target individual plots.
+    if (recipe.category === "speed_boost" || recipe.category === "seed_pouch") return false;
     // Allow null-tier plant utilities through; block all other null-tier items
     // (seed pouches, etc. are handled elsewhere).
     if (recipe.tier === null && !NULL_TIER_PLANT_CONSUMABLES.has(c.id)) return false;

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -289,7 +289,7 @@ export function PlotTooltip({
       className={`absolute ${flipped ? "top-full mt-2" : "bottom-full mb-2"} left-1/2 z-40 pointer-events-none`}
       style={{ transform: `translateX(calc(-50% + ${nudge}px))` }}
     >
-      <div className="pointer-events-auto bg-card/80 backdrop-blur-sm border border-border rounded-xl p-3 shadow-xl w-48 space-y-2">
+      <div className="pointer-events-auto bg-card/80 backdrop-blur-sm border border-border rounded-xl p-3 shadow-xl w-48 space-y-2 max-h-[80vh] overflow-y-auto">
 
         {/* Header */}
         <div className="flex items-center gap-2">

--- a/src/components/PlotTooltip.tsx
+++ b/src/components/PlotTooltip.tsx
@@ -138,8 +138,11 @@ export function PlotTooltip({
     if (c.quantity <= 0) return false;
     const recipe = CONSUMABLE_RECIPE_MAP[c.id as ConsumableId];
     if (!recipe) return false;
+    // Speed boosts (Forge Haste, Verdant Rush, Resonance Draft) are activated
+    // globally from the inventory — they don't target individual plots.
+    if (recipe.category === "speed_boost") return false;
     // Allow null-tier plant utilities through; block all other null-tier items
-    // (seed pouches, speed boosts, etc. are handled elsewhere).
+    // (seed pouches, etc. are handled elsewhere).
     if (recipe.tier === null && !NULL_TIER_PLANT_CONSUMABLES.has(c.id)) return false;
 
     // Magnifying Glass, Garden Pin, and Ruler bypass the rarity gate — they work on any species

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -14,6 +14,23 @@ export interface ChangelogEntry {
 // Most recent version first — update this with every release
 export const CHANGELOGS: ChangelogEntry[] = [
   {
+    version: "2.3.2",
+    title:   "Bug Fixes & Balance",
+    items: [
+      { type: "changed", text: "Balance Scale reworked — range fixed to 1 cell each side for all tiers; boost and slow now scale per tier: Scale I 4×/0.5× (avg 2.25×), Scale II 6×/0.33× (avg 3.165×), Scale III 8×/0.25× (avg 4.125×)" },
+      { type: "changed", text: "Shop seed prices are now floored to 2 significant figures (e.g. 1,234 → 1,200) for a cleaner shop UI" },
+      { type: "changed", text: "Scarecrow description corrected — now reads \"Blocks all mutations\" (it has always blocked gear mutations too, not just weather)" },
+      { type: "changed", text: "Fan description corrected — effect rate now reads \"each hour\" instead of \"each minute\"" },
+      { type: "changed", text: "Garden Pin description corrected — now references Lawn Mowers instead of Auto-Planters" },
+      { type: "fixed",   text: "Harvesting v2.3.1 flowers no longer fails — the harvest edge function was missing all 38 v2.3.1 species, returning \"Unknown species\" 400 errors on every harvest" },
+      { type: "fixed",   text: "Marketplace price history now shows the correct mutated price — listing base_value now includes the mutation multiplier so the chart reflects the actual listed price" },
+      { type: "fixed",   text: "Composter now generates fertilizer during offline ticks — composter logic was client-side only and is now also processed by the offline cron" },
+      { type: "fixed",   text: "Plot tooltip no longer shows Forge Haste or Seed Pouches — speed boosts and seed pouches don't target individual plots and are excluded from the per-plot consumable picker" },
+      { type: "fixed",   text: "Plot tooltip scrolls when many consumables are present — tooltip no longer extends off-screen on mobile with large consumable inventories" },
+      { type: "fixed",   text: "Shop no longer flickers after restock — stale server responses arriving after a client-side reset no longer overwrite the fresh shop list" },
+    ],
+  },
+  {
     version: "2.3.1",
     title:   "Flower Expansion & Fan Fix",
     items: [

--- a/src/data/consumables.ts
+++ b/src/data/consumables.ts
@@ -353,7 +353,7 @@ export const CONSUMABLE_RECIPES: ConsumableRecipe[] = [
   // (Harvest Bell, Auto-Planter). Player can still manually harvest at will.
   // Works on any rarity, like Magnifying Glass.
   { id: "garden_pin", name: "Garden Pin", emoji: "📌", tier: null, rarity: "rare", category: "utility",
-    description: "Pins a plot — its bloom won't be auto-harvested by Harvest Bells or Auto-Planters.",
+    description: "Pins a plot — its bloom won't be auto-harvested by Harvest Bells or Lawn Mowers.",
     cost: { kind: "essence", amounts: [{ type: "arcane", amount: 4 }, { type: "fairy", amount: 4 }] } },
 
   // ── Ruler (non-tiered) — utility ─────────────────────────────────────────

--- a/src/data/gear.ts
+++ b/src/data/gear.ts
@@ -444,7 +444,7 @@ export const GEAR: Record<GearType, GearDefinition> = {
   scarecrow_rare: {
     id:             "scarecrow_rare",
     name:           "Scarecrow I",
-    description:    "Blocks weather mutations on nearby plants. Has a 15% chance per hour to strip an existing mutation. Lasts 4 hours.",
+    description:    "Blocks all mutations on nearby plants. Has a 15% chance per hour to strip an existing mutation. Lasts 4 hours.",
     emoji:          "🧹",
     rarity:         "rare",
     shopPrice:      1400,
@@ -458,7 +458,7 @@ export const GEAR: Record<GearType, GearDefinition> = {
   scarecrow_legendary: {
     id:             "scarecrow_legendary",
     name:           "Scarecrow II",
-    description:    "Blocks weather mutations on nearby plants. Has a 25% chance per hour to strip an existing mutation. Lasts 8 hours.",
+    description:    "Blocks all mutations on nearby plants. Has a 25% chance per hour to strip an existing mutation. Lasts 8 hours.",
     emoji:          "🧹",
     rarity:         "legendary",
     shopPrice:      15_000,
@@ -472,7 +472,7 @@ export const GEAR: Record<GearType, GearDefinition> = {
   scarecrow_mythic: {
     id:             "scarecrow_mythic",
     name:           "Scarecrow III",
-    description:    "Blocks weather mutations on nearby plants in a wide area. Has a 40% chance per hour to strip an existing mutation. Lasts 12 hours.",
+    description:    "Blocks all mutations on nearby plants in a wide area. Has a 40% chance per hour to strip an existing mutation. Lasts 12 hours.",
     emoji:          "🧹",
     rarity:         "mythic",
     shopPrice:      100_000,
@@ -532,7 +532,7 @@ export const GEAR: Record<GearType, GearDefinition> = {
   fan_uncommon: {
     id:                    "fan_uncommon",
     name:                  "Fan I",
-    description:           "Blows in one direction across 2 plants. Low chance to strip Wet from blooms each minute. Very low chance to apply Windstruck to unmutated blooms. Lasts 2 hours.",
+    description:           "Blows in one direction across 2 plants. Low chance to strip Wet from blooms each hour. Very low chance to apply Windstruck to unmutated blooms. Lasts 2 hours.",
     emoji:                 "💨",
     rarity:                "uncommon",
     shopPrice:             600,
@@ -547,7 +547,7 @@ export const GEAR: Record<GearType, GearDefinition> = {
   fan_rare: {
     id:                    "fan_rare",
     name:                  "Fan II",
-    description:           "Blows in one direction across 3 plants. Moderate chance to strip Wet from blooms each minute. Very low chance to apply Windstruck to unmutated blooms. Lasts 4 hours.",
+    description:           "Blows in one direction across 3 plants. Moderate chance to strip Wet from blooms each hour. Very low chance to apply Windstruck to unmutated blooms. Lasts 4 hours.",
     emoji:                 "💨",
     rarity:                "rare",
     shopPrice:             2400,
@@ -562,7 +562,7 @@ export const GEAR: Record<GearType, GearDefinition> = {
   fan_legendary: {
     id:                    "fan_legendary",
     name:                  "Fan III",
-    description:           "Blows in one direction across 4 plants. High chance to strip Wet from blooms each minute. Very low chance to apply Windstruck to unmutated blooms. Lasts 8 hours.",
+    description:           "Blows in one direction across 4 plants. High chance to strip Wet from blooms each hour. Very low chance to apply Windstruck to unmutated blooms. Lasts 8 hours.",
     emoji:                 "💨",
     rarity:                "legendary",
     shopPrice:             16_000,

--- a/src/data/gear.ts
+++ b/src/data/gear.ts
@@ -179,6 +179,10 @@ export interface GearDefinition {
   fanWindstruckChancePerTick?: number;
   /** Scarecrow: per-tick probability to strip an existing mutation from a covered plant */
   mutationStripChancePerTick?: number;
+  /** Balance scale: growth multiplier applied to the boosted side */
+  scaleBoostMult?: number;
+  /** Balance scale: growth multiplier applied to the slowed side */
+  scaleSlowMult?: number;
 }
 
 // ── Radius pattern helpers ─────────────────────────────────────────────────
@@ -756,7 +760,7 @@ export const GEAR: Record<GearType, GearDefinition> = {
   balance_scale_legendary: {
     id:             "balance_scale_legendary",
     name:           "Balance Scale I",
-    description:    "Alternates every hour: the left cell grows 3× faster while the right cell grows 0.5× slower — then swaps. Lasts 8 hours.",
+    description:    "Alternates every hour: the left cell grows 4× faster while the right cell grows 0.5× slower — then swaps. Lasts 8 hours.",
     emoji:          "⚖️",
     rarity:         "legendary",
     shopPrice:      30_000,
@@ -764,32 +768,38 @@ export const GEAR: Record<GearType, GearDefinition> = {
     passiveSubtype: "balance_scale",
     durationMs:     DURATION_8H,
     fanRange:       1,
+    scaleBoostMult: 4.0,
+    scaleSlowMult:  0.5,
   },
 
   balance_scale_mythic: {
     id:             "balance_scale_mythic",
     name:           "Balance Scale II",
-    description:    "Alternates every hour: the 2 left cells grow 3× faster while the 2 right cells grow 0.5× slower — then swaps. Lasts 10 hours.",
+    description:    "Alternates every hour: the left cell grows 6× faster while the right cell grows 0.33× slower — then swaps. Lasts 10 hours.",
     emoji:          "⚖️",
     rarity:         "mythic",
     shopPrice:      200_000,
     category:       "passive",
     passiveSubtype: "balance_scale",
     durationMs:     10 * 60 * 60 * 1_000,
-    fanRange:       2,
+    fanRange:       1,
+    scaleBoostMult: 6.0,
+    scaleSlowMult:  0.33,
   },
 
   balance_scale_exalted: {
     id:             "balance_scale_exalted",
     name:           "Balance Scale III",
-    description:    "Alternates every hour: the 3 left cells grow 3× faster while the 3 right cells grow 0.5× slower — then swaps. Lasts 12 hours.",
+    description:    "Alternates every hour: the left cell grows 8× faster while the right cell grows 0.25× slower — then swaps. Lasts 12 hours.",
     emoji:          "⚖️",
     rarity:         "exalted",
     shopPrice:      1_200_000,
     category:       "passive",
     passiveSubtype: "balance_scale",
     durationMs:     DURATION_12H,
-    fanRange:       3,
+    fanRange:       1,
+    scaleBoostMult: 8.0,
+    scaleSlowMult:  0.25,
   },
 
   // ── Auto-Planter ─────────────────────────────────────────────────────────

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -338,6 +338,11 @@ export const SHOP_RARITY_WEIGHTS: Partial<Record<Rarity, number>> = {
  * tighter margin (0.85 → 15%). Stops bulk-buying high-rarity seeds from being
  * a free coin printer once the player can afford them.
  */
+function floorToTwoSigFigs(n: number): number {
+  if (n < 100) return n;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(n)) - 1);
+  return Math.floor(n / magnitude) * magnitude;
+}
 const SEED_PRICE_RATIO: Record<Rarity, number> = {
   common:    0.65,
   uncommon:  0.68,
@@ -387,7 +392,7 @@ function generateShop(shopSlots: number = DEFAULT_SHOP_SLOTS): ShopSlot[] {
     usedIds.add(flower.id);
     chosen.push({
       speciesId: flower.id,
-      price:     Math.max(5, Math.floor(flower.sellValue * SEED_PRICE_RATIO[flower.rarity])),
+      price:     floorToTwoSigFigs(Math.max(5, Math.floor(flower.sellValue * SEED_PRICE_RATIO[flower.rarity]))),
       quantity:  Math.floor(Math.random() * 4) + 1,
     });
   }

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1001,14 +1001,14 @@ export function getPassiveGrowthMultiplier(
     // Phase 0 = left arm (dc < 0) boosted 3×; right arm (dc > 0) slowed 0.5×.
     // Phase 1 = flipped.
     if (isBalanceScale(def) && def.fanRange) {
-      const phase    = Math.floor(now / 3_600_000) % 2;
-      const dc       = col - sourceCol;
-      const inLeft   = dc < 0;
+      const phase     = Math.floor(now / 3_600_000) % 2;
+      const dc        = col - sourceCol;
+      const inLeft    = dc < 0;
       const isBoosted = phase === 0 ? inLeft : !inLeft;
       if (isBoosted) {
-        balanceScaleBoostMult = Math.max(balanceScaleBoostMult, 3.0);
+        balanceScaleBoostMult = Math.max(balanceScaleBoostMult, def.scaleBoostMult ?? 4.0);
       } else {
-        balanceScaleSlowMult = Math.min(balanceScaleSlowMult, 0.5);
+        balanceScaleSlowMult = Math.min(balanceScaleSlowMult, def.scaleSlowMult ?? 0.5);
       }
     }
   }

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -338,7 +338,7 @@ export const SHOP_RARITY_WEIGHTS: Partial<Record<Rarity, number>> = {
  * tighter margin (0.85 → 15%). Stops bulk-buying high-rarity seeds from being
  * a free coin printer once the player can afford them.
  */
-function floorToTwoSigFigs(n: number): number {
+export function floorToTwoSigFigs(n: number): number {
   if (n < 100) return n;
   const magnitude = Math.pow(10, Math.floor(Math.log10(n)) - 1);
   return Math.floor(n / magnitude) * magnitude;

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2044,14 +2044,16 @@ export function mergeServerResult<T extends Partial<GameState>>(
 ): GameState {
   const merged = { ...cur, ...result, ok: undefined } as GameState;
 
-  // Never let shop/supply reset timestamps roll backwards.  A stale server
-  // response (read from DB before an in-flight edgeSyncShop/edgeSyncSupplyShop
-  // write completes) would otherwise clobber the client's newer lastShopReset,
-  // causing the 1-second tick interval to fire a phantom restock — and the
-  // restock banner to reappear immediately after the user dismissed it.
+  // Never let shop/supply reset timestamps or shop lists roll backwards.
+  // A stale server response (read from DB before an in-flight edgeSyncShop/
+  // edgeSyncSupplyShop write completes) would otherwise clobber the client's
+  // new shop list with the old one — causing the visible flicker back to the
+  // pre-restock inventory.
   const r = result as Partial<GameState>;
   merged.lastShopReset   = Math.max(cur.lastShopReset,        r.lastShopReset   ?? 0);
   merged.lastSupplyReset = Math.max(cur.lastSupplyReset ?? 0, r.lastSupplyReset ?? 0);
+  if ((r.lastShopReset   ?? 0) < cur.lastShopReset)          merged.shop        = cur.shop;
+  if ((r.lastSupplyReset ?? 0) < (cur.lastSupplyReset ?? 0)) merged.supplyShop  = cur.supplyShop;
 
   if (result.grid) {
     // Identify the same plant by speciesId + timePlanted so we never copy a

--- a/supabase/functions/harvest/index.ts
+++ b/supabase/functions/harvest/index.ts
@@ -104,6 +104,26 @@ const FLOWER_GROWTH_TIMES: Record<string, { seed: number; sprout: number }> = {
   eternal_heart: { seed: 374_400_000, sprout: 748_800_000 }, moonrime: { seed: 385_000_000, sprout: 770_000_000 },
   nova_bloom: { seed: 403_200_000, sprout: 806_400_000 }, shadowgale: { seed: 415_000_000, sprout: 830_000_000 },
   princess_blossom: { seed: 432_000_000, sprout: 864_000_000 },
+  // v2.3.1 flowers
+  cloudveil: { seed: 83_000, sprout: 166_000 }, pepperbloom: { seed: 86_000, sprout: 172_000 },
+  showerbloom: { seed: 102_000, sprout: 204_000 }, creamcap: { seed: 108_000, sprout: 216_000 },
+  duskling: { seed: 112_000, sprout: 224_000 }, moongrass: { seed: 117_000, sprout: 234_000 },
+  owlsage: { seed: 122_000, sprout: 244_000 }, hexblossom: { seed: 135_000, sprout: 270_000 },
+  starfleck: { seed: 145_000, sprout: 290_000 }, cometail: { seed: 158_000, sprout: 316_000 },
+  flurrysprig: { seed: 93_000, sprout: 186_000 }, cloudgrass: { seed: 286_000, sprout: 572_000 },
+  glacierbud: { seed: 268_000, sprout: 536_000 }, brewleaf: { seed: 128_000, sprout: 256_000 },
+  chimebloom: { seed: 308_000, sprout: 616_000 }, evenfall: { seed: 328_000, sprout: 656_000 },
+  sundrift: { seed: 358_000, sprout: 716_000 }, moonspan: { seed: 378_000, sprout: 756_000 },
+  tanglewort: { seed: 418_000, sprout: 836_000 }, medalwort: { seed: 472_000, sprout: 944_000 },
+  topazbloom: { seed: 512_000, sprout: 1_024_000 }, blazecrown: { seed: 978_000, sprout: 1_956_000 },
+  terracotta: { seed: 1_050_000, sprout: 2_100_000 }, frostmark: { seed: 1_260_000, sprout: 2_520_000 },
+  coldsnap: { seed: 1_440_000, sprout: 2_880_000 }, voidpetal: { seed: 1_980_000, sprout: 3_960_000 },
+  galebloom: { seed: 6_200_000, sprout: 12_400_000 }, infernopetal: { seed: 19_800_000, sprout: 39_600_000 },
+  anchorweed: { seed: 25_200_000, sprout: 50_400_000 }, worldroot: { seed: 32_400_000, sprout: 64_800_000 },
+  clearingbloom: { seed: 39_600_000, sprout: 79_200_000 }, permafrost: { seed: 46_800_000, sprout: 93_600_000 },
+  frostspine: { seed: 50_400_000, sprout: 100_800_000 }, tempest_eye: { seed: 57_600_000, sprout: 115_200_000 },
+  thundercrown: { seed: 61_200_000, sprout: 122_400_000 }, moonsmile: { seed: 64_800_000, sprout: 129_600_000 },
+  dreamshade: { seed: 68_400_000, sprout: 136_800_000 }, gravewilt: { seed: 75_600_000, sprout: 151_200_000 },
 };
 
 // Max weather multiplier (thunderstorm 2×) used as grace factor

--- a/supabase/functions/marketplace-list/index.ts
+++ b/supabase/functions/marketplace-list/index.ts
@@ -46,6 +46,30 @@ const FLOWER_SELL_VALUES: Record<string, number> = {
   graveweb: 355_000, nightwing: 430_000, ashenveil: 465_000, voidfire: 500_000,
   dreambloom: 1_000_000, fairy_blossom: 1_200_000, lovebind: 1_350_000,
   eternal_heart: 1_550_000, nova_bloom: 1_800_000, princess_blossom: 2_000_000,
+  // v2.3.0 & v2.3.1 additions
+  stormcap: 14, stardust: 16, moonstrike: 56, winterwood: 325,
+  galebloom: 4_000, infernopetal: 51_000, anchorweed: 55_000, worldroot: 60_000,
+  clearingbloom: 65_000, permafrost: 71_000, frostspine: 75_000, tempest_eye: 79_000,
+  thundercrown: 81_000, moonsmile: 84_000, dreamshade: 87_000, gravewilt: 93_000,
+  deeproot: 320_000, rimestorm: 365_000, solglow: 440_000,
+  islebloom: 1_400_000, moonrime: 1_650_000, shadowgale: 1_900_000,
+  cloudveil: 14, pepperbloom: 14, flurrysprig: 14, showerbloom: 15, creamcap: 15,
+  duskling: 16, moongrass: 16, owlsage: 17, brewleaf: 17, hexblossom: 18,
+  starfleck: 18, cometail: 19, glacierbud: 45, cloudgrass: 48, chimebloom: 51,
+  evenfall: 54, sundrift: 58, moonspan: 61, tanglewort: 66, medalwort: 74,
+  topazbloom: 80, blazecrown: 265, terracotta: 275, frostmark: 310, coldsnap: 340,
+  voidpetal: 430,
+  // Cropsticks cross-breed outputs
+  phoenix_lily: 22_000, eclipse_bloom: 24_000, tempest_orchid: 26_000,
+  blightmantle: 28_000, cosmosbloom: 30_000, dreamgust: 32_000,
+  solarburst: 130_000, tidalune: 150_000, whisperleaf: 170_000, crystalmind: 190_000,
+  void_chrysalis: 700_000, starloom: 800_000, the_first_bloom: 5_000_000,
+};
+
+// ── Mutation sell multipliers (mirrors src/data/flowers.ts) ──────────────────
+const MUTATION_MULTIPLIERS: Record<string, number> = {
+  golden: 4.0, rainbow: 5.0, giant: 2.0, moonlit: 2.5,
+  frozen: 2.0, scorched: 2.0, wet: 1.1, windstruck: 0.7, shocked: 2.5,
 };
 
 // ── Fertilizer shop prices (mirrors src/data/upgrades.ts) ────────────────────
@@ -475,7 +499,8 @@ Deno.serve(async (req: Request) => {
         .map((i, idx) => idx === itemIdx ? { ...i, quantity: i.quantity - 1 } : i)
         .filter((i) => i.quantity > 0);
 
-      const baseValue = FLOWER_SELL_VALUES[body.speciesId] ?? 0;
+      const mutMultiplier = body.mutation ? (MUTATION_MULTIPLIERS[body.mutation] ?? 1.0) : 1.0;
+      const baseValue = Math.floor((FLOWER_SELL_VALUES[body.speciesId] ?? 0) * mutMultiplier);
 
       // Insert listing
       const { data: listing, error: insertError } = await supabaseAdmin

--- a/supabase/functions/tick-offline-gardens/index.ts
+++ b/supabase/functions/tick-offline-gardens/index.ts
@@ -114,7 +114,9 @@ const OFFSETS_DIAMOND: [number, number][] = [
 
 // ── Gear definitions ───────────────────────────────────────────────────────
 interface GearDef {
-  subtype: "harvest_bell" | "auto_planter" | "scarecrow" | "aegis" | "lawnmower" | "fan" | "sprinkler_regular" | "sprinkler_mutation";
+  subtype: "harvest_bell" | "auto_planter" | "scarecrow" | "aegis" | "lawnmower" | "fan" | "sprinkler_regular" | "sprinkler_mutation" | "composter";
+  /** Composter only — max fertilizers that can be stored before collection. */
+  maxStorage?: number;
   /** Radius offsets for radial gear (harvest bell, auto-planter, scarecrow, sprinklers). */
   offsets?: [number, number][];
   /** Line-of-sight cell count for directional gear (fan, aegis, lawnmower). */
@@ -137,6 +139,10 @@ const GEAR_DEFS: Record<string, GearDef> = {
   harvest_bell_rare:      { subtype: "harvest_bell", offsets: OFFSETS_CROSS,   durationMs:  4 * 60 * 60 * 1_000 },
   harvest_bell_legendary: { subtype: "harvest_bell", offsets: OFFSETS_3X3,     durationMs:  8 * 60 * 60 * 1_000 },
   auto_planter_prismatic: { subtype: "auto_planter", offsets: OFFSETS_DIAMOND, durationMs: 12 * 60 * 60 * 1_000 },
+  // Composter — generates a fertilizer each time a nearby plant blooms
+  composter_uncommon:  { subtype: "composter", offsets: OFFSETS_3X3,     durationMs:  4 * 60 * 60 * 1_000, maxStorage: 10 },
+  composter_rare:      { subtype: "composter", offsets: OFFSETS_3X3,     durationMs:  8 * 60 * 60 * 1_000, maxStorage: 20 },
+  composter_legendary: { subtype: "composter", offsets: OFFSETS_DIAMOND, durationMs: 12 * 60 * 60 * 1_000, maxStorage: 30 },
   // Scarecrow — blocks weather AND gear mutations within radius, plus strip chance
   scarecrow_rare:         { subtype: "scarecrow", offsets: OFFSETS_3X3,     durationMs:  4 * 60 * 60 * 1_000, scarecrowStripPerHour: 0.15 },
   scarecrow_legendary:    { subtype: "scarecrow", offsets: OFFSETS_3X3,     durationMs:  8 * 60 * 60 * 1_000, scarecrowStripPerHour: 0.25 },
@@ -431,6 +437,65 @@ function rollSprinklers(grid: Plot[][], shieldCoverage: Map<string, CoverageEntr
   }
 
   return { grid: changed ? next : grid, changed };
+}
+
+// ── Composter ─────────────────────────────────────────────────────────────
+function rollComposterFertilizer(rarity: string): string {
+  const table: Record<string, Record<string, number>> = {
+    common:    { basic: 50, advanced: 30, premium: 15, elite: 4,  miracle: 1  },
+    uncommon:  { basic: 35, advanced: 35, premium: 20, elite: 8,  miracle: 2  },
+    rare:      { basic: 20, advanced: 30, premium: 30, elite: 15, miracle: 5  },
+    legendary: { basic: 10, advanced: 20, premium: 30, elite: 25, miracle: 15 },
+    mythic:    { basic: 5,  advanced: 15, premium: 25, elite: 30, miracle: 25 },
+    exalted:   { basic: 3,  advanced: 10, premium: 20, elite: 30, miracle: 37 },
+    prismatic: { basic: 2,  advanced: 8,  premium: 15, elite: 25, miracle: 50 },
+  };
+  const weights = table[rarity] ?? table.common;
+  const total   = Object.values(weights).reduce((s, w) => s + w, 0);
+  let roll      = Math.random() * total;
+  for (const [type, weight] of Object.entries(weights)) {
+    roll -= weight;
+    if (roll <= 0) return type;
+  }
+  return "basic";
+}
+
+function runComposters(originalGrid: Plot[][], stampedGrid: Plot[][], now: number): Plot[][] {
+  const rows = stampedGrid.length;
+  const cols = stampedGrid[0]?.length ?? 0;
+  let grid = stampedGrid;
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const wasBloom = !!(originalGrid[r]?.[c]?.plant?.bloomedAt);
+      const nowBloom = !!(stampedGrid[r]?.[c]?.plant?.bloomedAt);
+      if (wasBloom || !nowBloom) continue; // only newly bloomed this tick
+
+      const speciesId = stampedGrid[r][c].plant!.speciesId;
+      const rarity    = SPECIES_DATA[speciesId]?.r ?? "common";
+
+      for (const [dr, dc] of OFFSETS_3X3) {
+        const cr = r + dr;
+        const cc = c + dc;
+        if (cr < 0 || cr >= rows || cc < 0 || cc >= cols) continue;
+        const plot = grid[cr][cc];
+        if (!plot.gear) continue;
+        const def = GEAR_DEFS[plot.gear.gearType];
+        if (!def || def.subtype !== "composter") continue;
+        if (isExpired(plot.gear, now)) continue;
+        const stored   = (plot.gear.storedFertilizers ?? []) as string[];
+        const maxStore = def.maxStorage ?? 10;
+        if (stored.length >= maxStore) continue;
+
+        const fertType  = rollComposterFertilizer(rarity);
+        const newGear   = { ...plot.gear, storedFertilizers: [...stored, fertType] };
+        grid = grid.map((row, ri) =>
+          ri !== cr ? row : row.map((p, ci) => ci !== cc ? p : { ...p, gear: newGear })
+        );
+      }
+    }
+  }
+  return grid;
 }
 
 // ── Stamp bloomedAt ────────────────────────────────────────────────────────
@@ -1171,6 +1236,12 @@ Deno.serve(async (req: Request) => {
       // 1. Stamp bloomedAt so harvest bell + mutations can find ready plants
       const { grid: stamped, changed: stampChanged } = stampBloomed(original.grid, now, weatherMult);
       let sim = stampChanged ? { ...original, grid: stamped } : original;
+
+      // 1b. Feed composters from plants that just bloomed this tick
+      if (stampChanged) {
+        const compGrid = runComposters(original.grid, stamped, now);
+        if (compGrid !== stamped) sim = { ...sim, grid: compGrid };
+      }
 
       // 2a. Build mutation-shield coverage once per garden (Scarecrow + Aegis)
       const shieldCoverage = buildShieldCoverage(sim.grid, now);

--- a/tests/unit/gameStore.merge.test.ts
+++ b/tests/unit/gameStore.merge.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   defaultState,
+  floorToTwoSigFigs,
   makeGrid,
   mergeServerResult,
   type GameState,
+  type ShopSlot,
 } from "../../src/store/gameStore";
 
 // ── Test helpers ────────────────────────────────────────────────────────────
@@ -144,7 +146,7 @@ describe("mergeServerResult — grid replacement preserves client-rolled mutatio
     expect(merged.grid[0][0].plant?.mutation).toBeUndefined();
   });
 
-  it("server's empty plot wins over a client plant (this is the bug WHY callers should return {})", () => {
+  it("server's empty plot wins over a client plant (this documents WHY callers should return {})", () => {
     // This documents the bug: if a Plant-All sibling's response includes a
     // grid where the cell is null but the client has it optimistically planted,
     // the server wins and the plant disappears. Callers avoid this by NOT
@@ -163,5 +165,78 @@ describe("mergeServerResult — grid replacement preserves client-rolled mutatio
     expect(merged.grid[0][0].plant?.speciesId).toBe("rose");
     // Daisy was wiped because server's grid wins on absence
     expect(merged.grid[0][1].plant).toBeNull();
+  });
+});
+
+// ── floorToTwoSigFigs ────────────────────────────────────────────────────────
+
+describe("floorToTwoSigFigs — shop seed price rounding (#174)", () => {
+  it("returns numbers below 100 unchanged", () => {
+    expect(floorToTwoSigFigs(0)).toBe(0);
+    expect(floorToTwoSigFigs(5)).toBe(5);
+    expect(floorToTwoSigFigs(99)).toBe(99);
+  });
+
+  it("returns exactly 100 as 100", () => {
+    expect(floorToTwoSigFigs(100)).toBe(100);
+  });
+
+  it("floors 3-digit numbers to 2 significant figures", () => {
+    expect(floorToTwoSigFigs(123)).toBe(120);
+    expect(floorToTwoSigFigs(999)).toBe(990);
+  });
+
+  it("floors 4-digit numbers to 2 significant figures", () => {
+    expect(floorToTwoSigFigs(1000)).toBe(1000);
+    expect(floorToTwoSigFigs(1234)).toBe(1200);
+    expect(floorToTwoSigFigs(9876)).toBe(9800);
+  });
+
+  it("floors 5-digit numbers to 2 significant figures", () => {
+    expect(floorToTwoSigFigs(10000)).toBe(10000);
+    expect(floorToTwoSigFigs(12345)).toBe(12000);
+    expect(floorToTwoSigFigs(98765)).toBe(98000);
+  });
+});
+
+// ── mergeServerResult — shop flicker (#172) ──────────────────────────────────
+
+describe("mergeServerResult — shop flicker protection (#172)", () => {
+  it("preserves client shop when server lastShopReset is stale", () => {
+    // Client just restocked (t=2000). A stale server response arrives that was
+    // read before the restock (t=1000). Without the guard, the server's old shop
+    // list would overwrite the client's fresh one, causing a visible flicker.
+    const clientShop: ShopSlot[] = [{ speciesId: "rose", price: 100, quantity: 3 }];
+    const serverShop: ShopSlot[] = [{ speciesId: "daisy", price: 50, quantity: 5 }];
+
+    const cur = baseState({ shop: clientShop, lastShopReset: 2000 });
+    const merged = mergeServerResult(cur, { shop: serverShop, lastShopReset: 1000 });
+
+    expect(merged.shop).toBe(clientShop);   // client shop reference preserved
+    expect(merged.lastShopReset).toBe(2000);
+  });
+
+  it("preserves client supplyShop when server lastSupplyReset is stale", () => {
+    const clientSupply: ShopSlot[] = [{ speciesId: "fan_uncommon", price: 200, quantity: 1, isGear: true }];
+    const serverSupply: ShopSlot[] = [{ speciesId: "fan_rare", price: 400, quantity: 1, isGear: true }];
+
+    const cur = baseState({ supplyShop: clientSupply, lastSupplyReset: 5000 });
+    const merged = mergeServerResult(cur, { supplyShop: serverSupply, lastSupplyReset: 3000 });
+
+    expect(merged.supplyShop).toBe(clientSupply);
+    expect(merged.lastSupplyReset).toBe(5000);
+  });
+
+  it("accepts server shop when server lastShopReset is newer (restock from another device)", () => {
+    // A second tab or device restocked the shop after this client's last reset.
+    // The server's newer shop should win.
+    const clientShop: ShopSlot[] = [{ speciesId: "rose", price: 100, quantity: 3 }];
+    const serverShop: ShopSlot[] = [{ speciesId: "daisy", price: 50, quantity: 5 }];
+
+    const cur = baseState({ shop: clientShop, lastShopReset: 1000 });
+    const merged = mergeServerResult(cur, { shop: serverShop, lastShopReset: 2000 });
+
+    expect(merged.shop).toEqual(serverShop); // server wins
+    expect(merged.lastShopReset).toBe(2000);
   });
 });


### PR DESCRIPTION
## Summary

### Fixed
- Harvesting v2.3.1 flowers no longer returns "Unknown species" 400 — all 38 species were missing from the harvest edge function's `FLOWER_GROWTH_TIMES` (#175)
- Marketplace price history now shows the correct mutated price — `base_value` now includes the mutation multiplier at listing creation (#156)
- Composter now generates fertilizer during offline ticks — was client-side only, now also runs in `tick-offline-gardens` (#158)
- Plot tooltip no longer shows Forge Haste or Seed Pouches in the consumable picker (#177 / #173)
- Plot tooltip now scrolls when many consumables are present — no longer extends off-screen (#171)
- Shop no longer flickers after restock — `mergeServerResult` now protects shop/supplyShop from stale server responses (#172)

### Changed
- Balance Scale reworked — range fixed to 1 cell each side for all tiers; boost/slow now scales per tier: Scale I 4×/0.5×, Scale II 6×/0.33×, Scale III 8×/0.25× (#181)
- Shop seed prices floored to 2 significant figures for a cleaner UI (#174)
- Scarecrow, Fan, and Garden Pin descriptions corrected

### Infra
- Unit tests added for `floorToTwoSigFigs` and shop flicker guard
- QA checklist sections S–W added for all v2.3.2 changes

## Test plan

- [ ] Harvest a v2.3.1 flower — no 400 error, bloom added to inventory
- [ ] List a mutated flower on marketplace — price history shows mutated price
- [ ] Navigate away with a Composter placed — returns to fertilizer applied on bloomed plots
- [ ] Open plot tooltip with Forge Haste in inventory — not shown in consumable list
- [ ] Open plot tooltip with 10+ consumables — tooltip scrolls, nothing cut off
- [ ] Trigger a shop restock — no flicker back to old shop items
- [ ] Place Balance Scale I next to two plots — 4× boost / 0.5× slow; swaps after the hour
- [ ] `npm run typecheck && npm run test:ci` pass