### PR TITLE
feat(gems): gems foundation 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -640,6 +640,7 @@ function AppInner() {
             </button>
             <ActiveBoostsHUD activeBoosts={state.activeBoosts} />
             <span className="text-sm font-mono" title={state.coins.toLocaleString()}>🟡 {formatCoins(state.coins)}</span>
+            <span className="text-sm font-mono" title={state.gems.toLocaleString()}>💎 {state.gems.toLocaleString()}</span>
             {!authLoading && (
               user ? (
                 <div className="flex items-center gap-2">

--- a/src/components/DailyTasksPanel.tsx
+++ b/src/components/DailyTasksPanel.tsx
@@ -28,10 +28,10 @@ function taskLabel(type: DailyTaskType, target: number): string {
 // ── Reward tier definitions ───────────────────────────────────────────────────
 
 const REWARDS = [
-  { xp:  50, label: "Seed Pouch I"   },
-  { xp:  75, label: "Seed Pouch I"   },
-  { xp: 100, label: "Seed Pouch II"  },
-  { xp: 200, label: "Seed Pouch III" },
+  { xp:  50, label: "Seed Pouch I",   gems: 10 },
+  { xp:  75, label: "Seed Pouch I",   gems: 15 },
+  { xp: 100, label: "Seed Pouch II",  gems: 20 },
+  { xp: 200, label: "Seed Pouch III", gems: 35 },
 ] as const;
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -121,7 +121,7 @@ export function DailyTasksPanel() {
               }`}>
                 {collected ? "✓" : i + 1}
               </span>
-              <span className={collected ? "line-through" : ""}>{reward.xp} XP + {reward.label}</span>
+              <span className={collected ? "line-through" : ""}>{reward.xp} XP + {reward.label} + {reward.gems} 💎</span>
             </div>
           );
         })}

--- a/src/hooks/useDailyProgress.ts
+++ b/src/hooks/useDailyProgress.ts
@@ -42,6 +42,7 @@ export function useDailyProgress() {
         consumables:     result.consumables     ?? cur.consumables,
         gardenerLevel:   result.gardenerLevel   ?? cur.gardenerLevel,
         gardenerXp:      result.gardenerXp      ?? cur.gardenerXp,
+        gems:            result.gems            ?? cur.gems,
         serverUpdatedAt: result.serverUpdatedAt,
       });
 

--- a/src/lib/edgeFunctions.ts
+++ b/src/lib/edgeFunctions.ts
@@ -721,6 +721,8 @@ export interface DailyCompleteResult {
   leveledUp?:      boolean;
   levelsGained?:   number;
   rewardPouch?:    string;
+  gemsGained?:     number;
+  gems?:           number;
   serverUpdatedAt: string;
 }
 

--- a/src/store/cloudSave.ts
+++ b/src/store/cloudSave.ts
@@ -172,6 +172,8 @@ export async function loadCloudSave(userId: string): Promise<GameState | null> {
       gardenerXp:           (data.gardener_xp           as number)                      ?? 0,
       // v2.4 — Daily tasks
       dailyTasks:           (data.daily_tasks           as GameState["dailyTasks"])      ?? null,
+      // v2.4 — Gems
+      gems:                 (data.gems                  as number)                       ?? 0,
     } as GameState;
 
     // ── Gardener XP backfill (first load post-deploy) ──────────────────────
@@ -273,6 +275,8 @@ export async function saveToCloud(
     gardener_xp:            state.gardenerXp        ?? 0,
     // v2.4 — Daily tasks
     daily_tasks:            state.dailyTasks        ?? null,
+    // v2.4 — Gems
+    gems:                   state.gems              ?? 0,
     updated_at:             newUpdatedAt,
   };
 
@@ -378,6 +382,7 @@ export async function getPublicSave(userId: string): Promise<GameState | null> {
     gardenerLevel:        (data.gardener_level        as number)                          ?? 1,
     gardenerXp:           (data.gardener_xp           as number)                          ?? 0,
     dailyTasks:           null,
+    gems:                 (data.gems                  as number)                       ?? 0,
   } as GameState;
 }
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -244,6 +244,7 @@ export interface GameState {
   gardenerLevel: number,
   gardenerXp: number,
   dailyTasks: DailyTaskState | null,
+  gems:       number,
 }
 
 export interface OfflineSummary {
@@ -548,6 +549,7 @@ export function defaultState(): GameState {
     gardenerLevel:        1,
     gardenerXp:           0,
     dailyTasks:           null,
+    gems:                 0,
   };
 }
 
@@ -642,6 +644,7 @@ export function applyOfflineTick(
     gardenerLevel:        save.gardenerLevel         ?? 1,
     gardenerXp:           save.gardenerXp            ?? 0,
     dailyTasks:           save.dailyTasks            ?? null,
+    gems:                 save.gems                  ?? 0,
   };
 
   let shopRestocked    = false;

--- a/supabase/functions/daily-complete/index.ts
+++ b/supabase/functions/daily-complete/index.ts
@@ -19,10 +19,10 @@ const err = (msg: string, status = 400) => json({ error: msg }, status);
 
 // ── Reward tiers (indexed 0–3 by completion count) ───────────────────────────
 const DAILY_REWARDS = [
-  { xp:  50, pouch: "seed_pouch_1" },
-  { xp:  75, pouch: "seed_pouch_1" },
-  { xp: 100, pouch: "seed_pouch_2" },
-  { xp: 200, pouch: "seed_pouch_3" },
+  { xp:  50, pouch: "seed_pouch_1", gems: 10 },
+  { xp:  75, pouch: "seed_pouch_1", gems: 15 },
+  { xp: 100, pouch: "seed_pouch_2", gems: 20 },
+  { xp: 200, pouch: "seed_pouch_3", gems: 35 },
 ] as const;
 
 const TASKS_REQUIRED = 4;
@@ -83,7 +83,7 @@ Deno.serve(async (req: Request) => {
     const [authResult, saveResult] = await Promise.all([
       supabaseAdmin.auth.getUser(token),
       supabaseAdmin.from("game_saves")
-        .select("daily_tasks, consumables, gardener_level, gardener_xp, updated_at")
+        .select("daily_tasks, consumables, gems, gardener_level, gardener_xp, updated_at")
         .eq("user_id", userId)
         .single(),
     ]);
@@ -99,6 +99,7 @@ Deno.serve(async (req: Request) => {
     const gardenerXp     = (save.gardener_xp    as number) ?? 0;
     const consumables    = (save.consumables     ?? []) as Consumable[];
     const dailyTasks     = (save.daily_tasks     ?? {})  as Partial<DailyTaskState>;
+    const gems           = (save.gems            as number) ?? 0;
 
     // ── Validate daily state is fresh ─────────────────────────────────────────
     const today = utcDateString();
@@ -142,7 +143,7 @@ Deno.serve(async (req: Request) => {
 
     const newConsumables = addConsumable(consumables, reward.pouch);
     const { level: newLevel, xp: newXp, leveledUp, levelsGained } = awardXp(gardenerLevel, gardenerXp, reward.xp);
-
+    const newGems = gems + reward.gems;
     const newDailyTasks: DailyTaskState = { date: today, tasks: newTasks, rewardsCollected: newRewardsCollected };
 
     // ── CAS write ─────────────────────────────────────────────────────────────
@@ -153,6 +154,7 @@ Deno.serve(async (req: Request) => {
         consumables:    newConsumables,
         gardener_level: newLevel,
         gardener_xp:    newXp,
+        gems:           newGems,
         updated_at:     new Date().toISOString(),
       })
       .eq("user_id", userId)
@@ -164,7 +166,7 @@ Deno.serve(async (req: Request) => {
 
     void supabaseAdmin.from("action_log").insert({
       user_id: userId, action: "daily_complete",
-      payload: { taskType, tier: tierIdx + 1, reward: reward.pouch, xpGained: reward.xp },
+      payload: { taskType, tier: tierIdx + 1, reward: reward.pouch, xpGained: reward.xp, gemsGained: reward.gems },
     });
 
     return json({
@@ -177,6 +179,8 @@ Deno.serve(async (req: Request) => {
       leveledUp,
       levelsGained,
       rewardPouch:     reward.pouch,
+      gemsGained:      reward.gems,
+      gems:            newGems,
       serverUpdatedAt: ud.updated_at,
     });
 

--- a/supabase/migrations/20260508000017_gems.sql
+++ b/supabase/migrations/20260508000017_gems.sql
@@ -1,0 +1,4 @@
+-- Add gems currency column to game_saves
+-- Earn-only in v2.4.0; spending mechanics deferred to v2.5.0+
+ALTER TABLE game_saves
+  ADD COLUMN IF NOT EXISTS gems INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

- Adds `gems` as a new earn-only currency (v2.4.0 scope; spending/IAP deferred to v2.5.0+)
- Daily task reward tiers now grant gems alongside XP and seed pouches (10/15/20/35 💎, up to 80/day)
- Gem balance is persisted in `game_saves`, loaded on login, saved optimistically, and displayed in the HUD next to 💎

## Changes

- `migration 20260508000017` — `gems INTEGER NOT NULL DEFAULT 0` column on `game_saves` ✅ applied
- `daily-complete` edge function — reward tiers include `gems` field; CAS write persists new balance ✅ deployed
- `GameState` + `cloudSave` — `gems` loaded from DB, included in save payload
- `useDailyProgress` — merges `gems` from server response into local state on task completion
- `DailyTasksPanel` — reward tier display shows gem amounts
- `App.tsx` — `💎 {gems}` counter in the sticky HUD header

## Held for v2.5.0+

- Gem spending UI
- IAP / gem top-up
- `upgrade` + `marketplace-list` edge function deploys (level-gate concern, unrelated to gems)

## Test plan

- [ ] Fresh load: HUD shows `💎 0` for new accounts
- [ ] Complete a daily task tier: HUD updates to correct gem amount, toast fires
- [ ] Reload page: gem balance persists from DB
- [ ] Complete all 4 tiers: total of 80 💎 awarded