### PR TITLE
feat(events): live event system — check-in and collection event types

### DIFF
--- a/src/components/EventsTab.tsx
+++ b/src/components/EventsTab.tsx
@@ -1,17 +1,28 @@
-import { useState } from "react";
+import { useState, ComponentType } from "react";
+import { useGame } from "../store/GameContext";
+import type { EventEntry } from "../store/gameStore";
+import { CheckinEventCard }    from "./events/CheckinEventCard";
+import { CollectionEventCard } from "./events/CollectionEventCard";
 import { DailyTasksPanel } from "./DailyTasksPanel";
 import { AchievementsPanel } from "./AchievementsPanel";
 
-type EventsView = "daily" | "achievements";
+// Maps event type string → card component. Unknown types render nothing.
+const EVENT_CARD_REGISTRY: Record<string, ComponentType<{ event: EventEntry }>> = {
+  checkin:    CheckinEventCard,
+  collection: CollectionEventCard,
+};
+
+type EventsView = "events" | "daily" | "achievements";
 
 export function EventsTab() {
-  const [view, setView] = useState<EventsView>("daily");
+  const { state } = useGame();
+  const [view, setView] = useState<EventsView>("events");
 
   return (
     <>
       {/* Sub-nav */}
       <div className="flex gap-2 mb-6">
-        {(["daily", "achievements"] as EventsView[]).map((v) => (
+        {(["events", "daily", "achievements"] as EventsView[]).map((v) => (
           <button
             key={v}
             onClick={() => setView(v)}
@@ -23,14 +34,31 @@ export function EventsTab() {
               }
             `}
           >
-            <span>{v === "daily" ? "📅" : "🏆"}</span>
+            <span>
+              {v === "events" ? "🌸" : v === "daily" ? "📅" : "🏆"}
+            </span>
             <span className="hidden sm:inline ml-1">
-              {v === "daily" ? "Daily Tasks" : "Achievements"}
+              {v === "events" ? "Events" : v === "daily" ? "Daily Tasks" : "Achievements"}
             </span>
           </button>
         ))}
       </div>
 
+      {view === "events" && (
+        <div className="flex flex-col gap-4">
+          {state.events.length === 0 ? (
+            <p className="text-xs text-center text-muted-foreground py-8">
+              No active events right now — check back soon! 🌱
+            </p>
+          ) : (
+            state.events.map((event) => {
+              const Card = EVENT_CARD_REGISTRY[event.type];
+              if (!Card) return null;
+              return <Card key={event.id} event={event} />;
+            })
+          )}
+        </div>
+      )}
       {view === "daily"        && <DailyTasksPanel />}
       {view === "achievements" && <AchievementsPanel />}
     </>

--- a/src/components/events/CheckinEventCard.tsx
+++ b/src/components/events/CheckinEventCard.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { useGame } from "../../store/GameContext";
+import type { EventEntry } from "../../store/gameStore";
+import { edgeCheckinClaim } from "../../lib/edgeFunctions";
+
+interface CheckinConfig {
+  days: { day: number; gems: number }[];
+}
+
+interface Props { event: EventEntry; }
+
+export function CheckinEventCard({ event }: Props) {
+  const { getState, update, pushGenericToast } = useGame();
+  const [claiming, setClaiming] = useState(false);
+
+  const config      = event.config as CheckinConfig;
+  const progress    = event.progress ?? {};
+  const claimedDays = progress.claimedDays ?? [];
+
+  const today               = new Date().toISOString().slice(0, 10);
+  const lastDate            = progress.lastClaimedAt
+    ? new Date(progress.lastClaimedAt).toISOString().slice(0, 10)
+    : null;
+  const alreadyClaimedToday = lastDate === today;
+
+  const nextDay    = claimedDays.length + 1;
+  const allClaimed = claimedDays.length >= config.days.length;
+  const canClaim   = !alreadyClaimedToday && !allClaimed;
+
+  async function handleClaim() {
+    if (!canClaim || claiming) return;
+    setClaiming(true);
+    try {
+      const result = await edgeCheckinClaim(event.id);
+      const cur = getState();
+      update({
+        ...cur,
+        gems:            result.gems,
+        serverUpdatedAt: result.serverUpdatedAt,
+        events:          cur.events.map((e) =>
+          e.id === event.id ? { ...e, progress: result.progress } : e
+        ),
+      });
+      pushGenericToast("checkin_claim", "💎", `Day ${result.claimedDay} claimed!`, undefined, "gain", result.gemsGained);
+    } catch (e) {
+      console.error("checkin claim failed:", e);
+    } finally {
+      setClaiming(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-border bg-card/60 p-4 flex flex-col gap-4">
+
+      {/* Header */}
+      <div>
+        <h3 className="font-bold text-sm">{event.name}</h3>
+        <p className="text-xs text-muted-foreground mt-0.5">{event.description}</p>
+      </div>
+
+      {/* Day grid — 7 columns */}
+      <div className="grid grid-cols-7 gap-1.5">
+        {config.days.map(({ day, gems }) => {
+          const claimed  = claimedDays.includes(day);
+          const isNext   = day === nextDay && !alreadyClaimedToday;
+          const isFuture = !claimed && !isNext;
+          return (
+            <div
+              key={day}
+              className={`
+                flex flex-col items-center justify-center rounded-xl border py-2 gap-0.5 text-center text-[10px]
+                ${claimed  ? "bg-primary/20 border-primary/40 text-primary"                          : ""}
+                ${isNext   ? "border-primary/60 bg-primary/10 text-foreground ring-1 ring-primary/40" : ""}
+                ${isFuture ? "border-border bg-card/30 text-muted-foreground"                        : ""}
+              `}
+            >
+              <span className="font-semibold">Day {day}</span>
+              <span>{claimed ? "✓" : `${gems} 💎`}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Claim button */}
+      {allClaimed ? (
+        <p className="text-xs text-center text-muted-foreground">All rewards claimed! 🎉</p>
+      ) : (
+        <button
+          onClick={handleClaim}
+          disabled={!canClaim || claiming}
+          className={`
+            w-full py-2 rounded-xl text-xs font-semibold transition-all
+            ${canClaim && !claiming
+              ? "bg-primary text-primary-foreground hover:opacity-90"
+              : "bg-muted text-muted-foreground cursor-not-allowed"
+            }
+          `}
+        >
+          {claiming
+            ? "Claiming…"
+            : alreadyClaimedToday
+            ? "Come back tomorrow"
+            : `Claim Day ${nextDay} (+${config.days[nextDay - 1]?.gems ?? 0} 💎)`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/events/CheckinEventCard.tsx
+++ b/src/components/events/CheckinEventCard.tsx
@@ -89,7 +89,7 @@ export function CheckinEventCard({ event }: Props) {
           onClick={handleClaim}
           disabled={!canClaim || claiming}
           className={`
-            w-full py-2 rounded-xl text-xs font-semibold transition-all
+            mx-auto block px-8 py-2 rounded-xl text-xs font-semibold transition-all
             ${canClaim && !claiming
               ? "bg-primary text-primary-foreground hover:opacity-90"
               : "bg-muted text-muted-foreground cursor-not-allowed"

--- a/src/components/events/CollectionEventCard.tsx
+++ b/src/components/events/CollectionEventCard.tsx
@@ -1,0 +1,201 @@
+import { useState, useMemo } from "react";
+import { useGame } from "../../store/GameContext";
+import type { EventEntry } from "../../store/gameStore";
+import { FLOWERS } from "../../data/flowers";
+import { edgeQuestSubmit } from "../../lib/edgeFunctions";
+
+interface QuestDef {
+  id:              string;
+  name:            string;
+  rarity:          string;
+  type:            string;
+  mutation:        string | null;
+  gems:            number;
+  xp:              number;
+  validSpeciesIds: string[];
+}
+
+interface CollectionConfig {
+  quests:      QuestDef[];
+  finalReward: { speciesId: string };
+}
+
+interface Props { event: EventEntry; }
+
+export function CollectionEventCard({ event }: Props) {
+  const { state, getState, update, pushGenericToast } = useGame();
+
+  const config          = event.config as CollectionConfig;
+  const completedQuests = event.progress?.completedQuests ?? [];
+
+  // First quest whose id isn't in completedQuests
+  const activeQuestIdx = config.quests.findIndex((q) => !completedQuests.includes(q.id));
+  const activeQuest    = activeQuestIdx >= 0 ? config.quests[activeQuestIdx] : null;
+  const allDone        = activeQuestIdx < 0;
+
+  // Blooms in inventory that satisfy the active quest's requirements
+  const eligibleBlooms = useMemo(() => {
+    if (!activeQuest) return [];
+    return state.inventory.filter((i) =>
+      !i.isSeed &&
+      activeQuest.validSpeciesIds.includes(i.speciesId) &&
+      (activeQuest.mutation === null || i.mutation === activeQuest.mutation) &&
+      i.quantity > 0,
+    );
+  }, [state.inventory, activeQuestIdx]);
+
+  const [selectedBloom, setSelectedBloom] = useState<{ speciesId: string; mutation: string | null } | null>(null);
+  const [submitting,    setSubmitting]    = useState(false);
+
+  async function handleSubmit() {
+    if (!activeQuest || !selectedBloom || submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await edgeQuestSubmit(
+        event.id,
+        activeQuest.id,
+        selectedBloom.speciesId,
+        selectedBloom.mutation,
+      );
+      const cur = getState();
+      update({
+        ...cur,
+        gems:            result.gems,
+        gardenerLevel:   result.gardenerLevel,
+        gardenerXp:      result.gardenerXp,
+        inventory:       result.inventory,
+        serverUpdatedAt: result.serverUpdatedAt,
+        events:          cur.events.map((e) =>
+          e.id === event.id ? { ...e, progress: result.progress } : e
+        ),
+      });
+      setSelectedBloom(null);
+      if (result.finalRewardDelivered) {
+        pushGenericToast("quest_final", "🌸", "Sakura seed delivered!", undefined, "gain", 1);
+      } else {
+        pushGenericToast("quest_submit", "💎", `Quest complete! +${result.gemsGained}`, undefined, "gain", result.gemsGained);
+      }
+    } catch (e) {
+      console.error("quest submit failed:", e);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-border bg-card/60 p-4 flex flex-col gap-4">
+
+      {/* Header */}
+      <div>
+        <h3 className="font-bold text-sm">{event.name}</h3>
+        <p className="text-xs text-muted-foreground mt-0.5">{event.description}</p>
+      </div>
+
+      {/* Quest list */}
+      <div className="flex flex-col gap-2">
+        {config.quests.map((quest, idx) => {
+          const done   = completedQuests.includes(quest.id);
+          const active = quest.id === activeQuest?.id;
+          const locked = !done && !active;
+          return (
+            <div
+              key={quest.id}
+              className={`
+                rounded-xl border p-3 flex flex-col gap-2
+                ${done   ? "border-primary/30 bg-primary/10"     : ""}
+                ${active ? "border-primary/60 bg-card"           : ""}
+                ${locked ? "border-border bg-card/30 opacity-50" : ""}
+              `}
+            >
+              {/* Quest header row */}
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold">
+                  {done ? "✓ " : `${idx + 1}. `}{quest.name}
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  {quest.gems} 💎 · {quest.xp} XP
+                </span>
+              </div>
+
+              {/* Requirement */}
+              <span className="text-[10px] text-muted-foreground">
+                {quest.rarity} · {quest.type}
+                {quest.mutation ? ` · ${quest.mutation}` : ""}
+              </span>
+
+              {/* Bloom picker — only shown on active quest */}
+              {active && (
+                <>
+                  {eligibleBlooms.length === 0 ? (
+                    <p className="text-[10px] text-muted-foreground italic">
+                      No matching flowers in inventory.
+                    </p>
+                  ) : (
+                    <div className="flex flex-wrap gap-1.5 mt-1">
+                      {eligibleBlooms.map((item) => {
+                        const flower     = FLOWERS.find((f) => f.id === item.speciesId);
+                        const isSelected =
+                          selectedBloom?.speciesId === item.speciesId &&
+                          selectedBloom?.mutation  === item.mutation;
+                        return (
+                          <button
+                            key={`${item.speciesId}:${item.mutation ?? "none"}`}
+                            onClick={() => setSelectedBloom({ speciesId: item.speciesId, mutation: item.mutation })}
+                            className={`
+                              text-[10px] px-2 py-1 rounded-lg border transition-all
+                              ${isSelected
+                                ? "bg-primary/20 border-primary/60 text-primary"
+                                : "bg-card border-border hover:border-primary/40"
+                              }
+                            `}
+                          >
+                            {flower?.emoji.bloom ?? "🌸"} {flower?.name ?? item.speciesId}
+                            {item.mutation ? ` (${item.mutation})` : ""}
+                            {item.quantity > 1 ? ` ×${item.quantity}` : ""}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  <button
+                    onClick={handleSubmit}
+                    disabled={!selectedBloom || submitting}
+                    className={`
+                      w-full py-2 rounded-xl text-xs font-semibold transition-all mt-1
+                      ${selectedBloom && !submitting
+                        ? "bg-primary text-primary-foreground hover:opacity-90"
+                        : "bg-muted text-muted-foreground cursor-not-allowed"
+                      }
+                    `}
+                  >
+                    {submitting ? "Submitting…" : "Submit Flower"}
+                  </button>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Final reward preview */}
+      {(() => {
+        const rewardFlower = FLOWERS.find((f) => f.id === config.finalReward.speciesId);
+        return (
+          <div className={`
+            rounded-xl border p-3 flex items-center gap-3
+            ${allDone ? "border-primary/50 bg-primary/10" : "border-border bg-card/30 opacity-60"}
+          `}>
+            <span className="text-2xl">{rewardFlower?.emoji.seed ?? "🌱"}</span>
+            <div>
+              <p className="text-xs font-semibold">{rewardFlower?.name ?? "Exclusive Seed"}</p>
+              <p className="text-[10px] text-muted-foreground">
+                {allDone ? "Delivered to your inventory!" : "Final reward — complete all quests to unlock"}
+              </p>
+            </div>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/src/data/flowers.ts
+++ b/src/data/flowers.ts
@@ -69,18 +69,20 @@ export const FLOWER_TYPES: Record<FlowerType, FlowerTypeConfig> = {
 // ── Flower species ────────────────────────────────────────────────────────────
 
 export interface FlowerSpecies {
-  id: string;
-  name: string;
+  id:          string;
+  name:        string;
   description: string;
-  emoji: Record<GrowthStage, string>;
-  rarity: Rarity;
-  types: FlowerType[];
+  emoji:       Record<GrowthStage, string>;
+  rarity:      Rarity;
+  types:       FlowerType[];
   growthTime: {
-    seed: number;
+    seed:   number;
     sprout: number;
   };
-  sellValue: number;
-  shopWeight: number;
+  sellValue:   number;
+  shopWeight:  number;
+  eventOnly?:  boolean;
+  eventId?:    string;
 }
 
 export const FLOWERS: FlowerSpecies[] = [
@@ -2207,6 +2209,21 @@ export const FLOWERS: FlowerSpecies[] = [
     growthTime: { seed: 604_800_000, sprout: 1_209_600_000 },
     sellValue: 5_000_000,
     shopWeight: 0,
+  },
+
+  // ── EVENT-ONLY — exclusive to limited-time events, shopWeight always 0 ─────
+  {
+    id: "sakura_blossom",
+    name: "Sakura Blossom",
+    description: "A cherry blossom that blooms only during the Sakura Festival. Some say it carries the memory of every spring before it.",
+    emoji: { seed: "🌱", sprout: "🌿", bloom: "🌸" },
+    rarity: "prismatic",
+    types: ["fairy", "zephyr"],
+    growthTime: { seed: 259_200_000, sprout: 518_400_000 },
+    sellValue: 1_500_000,
+    shopWeight: 0,
+    eventOnly: true,
+    eventId: "spring_sakura",
   },
 ];
 

--- a/src/lib/edgeFunctions.ts
+++ b/src/lib/edgeFunctions.ts
@@ -748,3 +748,18 @@ export interface AchievementClaimResult {
 export function edgeAchievementClaim(achievementId: string) {
   return callEdge<AchievementClaimResult>("achievement-claim", { achievementId });
 }
+
+// ── Events ────────────────────────────────────────────────────────────────────
+
+export interface CheckinClaimResult {
+  ok:              true;
+  claimedDay:      number;
+  gemsGained:      number;
+  gems:            number;
+  progress:        { claimedDays: number[]; lastClaimedAt: string };
+  serverUpdatedAt: string;
+}
+
+export function edgeCheckinClaim(eventId: string) {
+  return callEdge<CheckinClaimResult>("event-checkin-claim", { eventId });
+}

--- a/src/lib/edgeFunctions.ts
+++ b/src/lib/edgeFunctions.ts
@@ -763,3 +763,26 @@ export interface CheckinClaimResult {
 export function edgeCheckinClaim(eventId: string) {
   return callEdge<CheckinClaimResult>("event-checkin-claim", { eventId });
 }
+
+export interface QuestSubmitResult {
+  ok:                   true;
+  questId:              string;
+  gemsGained:           number;
+  xpGained:             number;
+  finalRewardDelivered: boolean;
+  inventory:            GameState["inventory"];
+  progress:             { completedQuests: string[]; claimedRewards: string[] };
+  gardenerLevel:        number;
+  gardenerXp:           number;
+  gems:                 number;
+  serverUpdatedAt:      string;
+}
+
+export function edgeQuestSubmit(
+  eventId:   string,
+  questId:   string,
+  speciesId: string,
+  mutation:  string | null,
+) {
+  return callEdge<QuestSubmitResult>("event-quest-submit", { eventId, questId, speciesId, mutation });
+}

--- a/src/store/GameContext.tsx
+++ b/src/store/GameContext.tsx
@@ -20,6 +20,7 @@ import {
   loadCloudSave,
   saveToCloud,
   getProfile,
+  loadEvents,
   type CloudProfile,
 } from "./cloudSave";
 import { supabase } from "../lib/supabase";
@@ -268,6 +269,11 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         saveToUse = cloudSave;
       }
 
+      let loadedEvents: EventEntry[] = [];
+      try {
+        loadedEvents = await loadEvents(u.id);
+      } catch {}
+
       // Fetch current weather so offline growth can apply rain / storm bonuses.
       let offlineWeather: WeatherWindow | undefined;
       try {
@@ -288,7 +294,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       if (loadGen.current !== gen) return; // sign-out fired — discard
 
       const { state: ticked, summary } = applyOfflineTick(saveToUse, offlineWeather);
-      setState(ticked);
+      setState({ ...ticked, events: loadedEvents });
       setOfflineSummary(summary);
       if (summary.shopRestocked)   setShopJustRestocked(true);
       if (summary.supplyRestocked) setSupplyJustRestocked(true);
@@ -304,7 +310,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
 
       if (savedUpdatedAt) {
         // Keep serverUpdatedAt in sync so subsequent CAS writes use the correct stamp.
-        stateRef.current = { ...ticked, serverUpdatedAt: savedUpdatedAt };
+        stateRef.current = { ...ticked, events: loadedEvents, serverUpdatedAt: savedUpdatedAt };
         setState(stateRef.current);
       } else {
         // CAS failed — the offline cron or another process wrote to DB between our

--- a/src/store/cloudSave.ts
+++ b/src/store/cloudSave.ts
@@ -1,5 +1,5 @@
 import { supabase } from "../lib/supabase";
-import type { GameState } from "./gameStore";
+import type { GameState, EventEntry, EventProgress } from "./gameStore";
 import { awardXp, DISCOVERY_XP_BY_RARITY, MUTATION_DISCOVERY_BONUS } from "../data/gardenerLevel";
 import { getFlower } from "../data/flowers";
 import { freshDailyState, isStale } from "../lib/dailySeed";
@@ -222,6 +222,43 @@ export async function loadCloudSave(userId: string): Promise<GameState | null> {
   }
 }
 
+export async function loadEvents(userId: string): Promise<EventEntry[]> {
+  try {
+    const now = new Date().toISOString();
+
+    const { data: eventRows, error } = await supabase
+      .from("events")
+      .select("*")
+      .gte("ends_at", now)
+      .order("starts_at", { ascending: false });
+
+    if (error || !eventRows || eventRows.length === 0) return [];
+
+    const { data: progressRows } = await supabase
+      .from("event_progress")
+      .select("event_id, progress")
+      .eq("user_id", userId)
+      .in("event_id", eventRows.map((e) => e.id));
+
+    const progressMap = new Map(
+      (progressRows ?? []).map((p) => [p.event_id, p.progress as EventProgress])
+    );
+
+    return eventRows.map((e) => ({
+      id:          e.id          as string,
+      type:        e.type        as string,
+      name:        e.name        as string,
+      description: e.description as string,
+      startsAt:    e.starts_at   as string,
+      endsAt:      e.ends_at     as string,
+      config:      e.config,
+      progress:    progressMap.get(e.id) ?? null,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 /** Saves state to the cloud.
  *  Returns the new `updated_at` string on success, or `false` on failure (CAS miss or DB error).
  *  Callers should update `state.serverUpdatedAt` with the returned value so subsequent
@@ -393,6 +430,8 @@ export async function getPublicSave(userId: string): Promise<GameState | null> {
     // v2.4 — Achievements
     achievementStats:    (data.achievement_stats    as AchievementStats) ?? {},
     achievementsClaimed: (data.achievements_claimed as string[])         ?? [],
+    // v2.4 — Events (public save never needs event progress)
+    events:              [],
   } as GameState;
 }
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -24,6 +24,26 @@ import {
 import type { DailyTaskState } from "../lib/dailySeed";
 import type { AchievementStats } from "../data/achievements";
 
+// ── Events ───────────────────────────────────────────────────────────────────
+
+export interface EventProgress {
+  claimedDays?:     number[];
+  lastClaimedAt?:   string;
+  completedQuests?: string[];
+  claimedRewards?:  string[];
+}
+
+export interface EventEntry {
+  id:          string;
+  type:        string;
+  name:        string;
+  description: string;
+  startsAt:    string;
+  endsAt:      string;
+  config:      unknown;
+  progress:    EventProgress | null;
+}
+
 // ── Types ──────────────────────────────────────────────────────────────────
 
 export interface PlantedFlower {
@@ -248,6 +268,7 @@ export interface GameState {
   gems:       number,
   achievementStats:    AchievementStats,
   achievementsClaimed: string[],
+  events:              EventEntry[],
 }
 
 export interface OfflineSummary {
@@ -555,6 +576,7 @@ export function defaultState(): GameState {
     gems:                 0,
     achievementStats:    {},
     achievementsClaimed: [],
+    events: [],
   };
 }
 

--- a/supabase/functions/_shared/eventHelpers.ts
+++ b/supabase/functions/_shared/eventHelpers.ts
@@ -1,0 +1,94 @@
+// Shared utilities for event edge functions (event-checkin-claim, event-quest-submit, …).
+// Each new event type only needs its own edge function — this file handles the
+// common DB plumbing: loading the event row, reading/writing user progress.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface EventProgress {
+  claimedDays?:     number[];
+  lastClaimedAt?:   string;
+  completedQuests?: string[];
+  claimedRewards?:  string[];
+}
+
+export interface EventRow {
+  id:          string;
+  type:        string;
+  name:        string;
+  description: string;
+  starts_at:   string;
+  ends_at:     string;
+  // deno-lint-ignore no-explicit-any
+  config:      any;
+  created_at:  string;
+}
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Returns true if the event is currently running. */
+export function isEventActive(event: EventRow): boolean {
+  const now = Date.now();
+  return new Date(event.starts_at).getTime() <= now &&
+         new Date(event.ends_at).getTime()   >  now;
+}
+
+/**
+ * Fetches an event row by ID. Throws a descriptive error string if the event
+ * doesn't exist or has already ended — callers can return that string as a 400.
+ */
+export async function loadEvent(
+  supabase: SupabaseClient,
+  eventId:  string,
+): Promise<EventRow> {
+  const { data, error } = await supabase
+    .from("events")
+    .select("*")
+    .eq("id", eventId)
+    .single();
+
+  if (error || !data) throw "Event not found";
+  if (!isEventActive(data as EventRow)) throw "Event is not currently active";
+
+  return data as EventRow;
+}
+
+/**
+ * Returns the user's current progress for an event.
+ * Returns an empty object if no row exists yet (first interaction).
+ */
+export async function loadProgress(
+  supabase: SupabaseClient,
+  userId:   string,
+  eventId:  string,
+): Promise<EventProgress> {
+  const { data } = await supabase
+    .from("event_progress")
+    .select("progress")
+    .eq("user_id", userId)
+    .eq("event_id", eventId)
+    .single();
+
+  return (data?.progress as EventProgress) ?? {};
+}
+
+/**
+ * Upserts the user's progress for an event. Always call this after any
+ * successful claim/submit — it handles both insert (first claim) and update.
+ */
+export async function saveProgress(
+  supabase:  SupabaseClient,
+  userId:    string,
+  eventId:   string,
+  progress:  EventProgress,
+): Promise<void> {
+  await supabase
+    .from("event_progress")
+    .upsert(
+      { user_id: userId, event_id: eventId, progress, updated_at: new Date().toISOString() },
+      { onConflict: "user_id,event_id" },
+    );
+}

--- a/supabase/functions/event-checkin-claim/index.ts
+++ b/supabase/functions/event-checkin-claim/index.ts
@@ -1,0 +1,127 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { initSentry, Sentry } from "../_shared/sentry.ts";
+import { loadEvent, loadProgress, saveProgress } from "../_shared/eventHelpers.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin":  "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function b64url(s: string): string {
+  const t = s.replace(/-/g, "+").replace(/_/g, "/");
+  return t + "=".repeat((4 - t.length % 4) % 4);
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+const err = (msg: string, status = 400) => json({ error: msg }, status);
+
+Deno.serve(async (req: Request) => {
+  initSentry();
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  try {
+    // ── Auth ──────────────────────────────────────────────────────────────────
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return err("Unauthorized", 401);
+
+    const token = authHeader.replace("Bearer ", "");
+    let userId: string;
+    try {
+      userId = JSON.parse(atob(b64url(token.split(".")[1]))).sub;
+    } catch {
+      return err("Unauthorized", 401);
+    }
+
+    // ── Parse body ────────────────────────────────────────────────────────────
+    const { eventId } = await req.json() as { eventId?: string };
+    if (!eventId) return err("eventId is required");
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    // ── Verify auth ───────────────────────────────────────────────────────────
+    const { data: { user }, error: authErr } = await supabase.auth.getUser(token);
+    if (authErr || !user || user.id !== userId) return err("Unauthorized", 401);
+
+    // ── Load + validate event ─────────────────────────────────────────────────
+    // loadEvent throws a plain string if event not found or not active —
+    // caught below and returned as a 400.
+    const event = await loadEvent(supabase, eventId);
+    if (event.type !== "checkin") return err("Event is not a check-in event");
+
+    // ── Load progress ─────────────────────────────────────────────────────────
+    const progress    = await loadProgress(supabase, userId, eventId);
+    const claimedDays = progress.claimedDays ?? [];
+
+    // ── Guard: already claimed today (UTC date boundary) ──────────────────────
+    const today = new Date().toISOString().slice(0, 10);
+    if (progress.lastClaimedAt) {
+      const lastDate = new Date(progress.lastClaimedAt).toISOString().slice(0, 10);
+      if (lastDate === today) return err("Already claimed today — come back tomorrow", 409);
+    }
+
+    // ── Compute next day + reward ─────────────────────────────────────────────
+    const days    = event.config.days as Array<{ day: number; gems: number }>;
+    const nextDay = claimedDays.length + 1;
+    if (nextDay > days.length) return err("All check-in rewards already claimed", 409);
+
+    const reward = days[nextDay - 1];
+    if (!reward) return err("Reward not found for this day");
+
+    // ── Load game_saves ───────────────────────────────────────────────────────
+    const { data: save, error: se } = await supabase
+      .from("game_saves")
+      .select("gems, updated_at")
+      .eq("user_id", userId)
+      .single();
+    if (se || !save) return err("Save not found", 404);
+
+    const priorUpdatedAt = save.updated_at as string;
+    const newGems        = ((save.gems as number) ?? 0) + reward.gems;
+
+    // ── CAS write to game_saves ───────────────────────────────────────────────
+    const { data: ud, error: ue } = await supabase
+      .from("game_saves")
+      .update({ gems: newGems, updated_at: new Date().toISOString() })
+      .eq("user_id", userId)
+      .eq("updated_at", priorUpdatedAt)
+      .select("updated_at")
+      .single();
+    if (ue || !ud) return err("Save conflict — please retry", 409);
+
+    // ── Persist progress ──────────────────────────────────────────────────────
+    const newProgress = {
+      ...progress,
+      claimedDays:   [...claimedDays, nextDay],
+      lastClaimedAt: new Date().toISOString(),
+    };
+    await saveProgress(supabase, userId, eventId, newProgress);
+
+    // ── Audit log ─────────────────────────────────────────────────────────────
+    void supabase.from("action_log").insert({
+      user_id: userId, action: "event_checkin_claim",
+      payload: { eventId, day: nextDay, gemsGained: reward.gems },
+    });
+
+    return json({
+      ok:              true,
+      claimedDay:      nextDay,
+      gemsGained:      reward.gems,
+      gems:            newGems,
+      progress:        newProgress,
+      serverUpdatedAt: ud.updated_at,
+    });
+
+  } catch (e) {
+    // loadEvent throws plain strings for known errors (event not found, not active)
+    if (typeof e === "string") return err(e);
+    console.error("event-checkin-claim error:", e);
+    Sentry.captureException(e);
+    await Sentry.flush(2000);
+    return err("Internal server error", 500);
+  }
+});

--- a/supabase/functions/event-quest-submit/index.ts
+++ b/supabase/functions/event-quest-submit/index.ts
@@ -1,0 +1,207 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { initSentry, Sentry } from "../_shared/sentry.ts";
+import { awardXp } from "../_shared/gardenerLevel.ts";
+import { loadEvent, loadProgress, saveProgress } from "../_shared/eventHelpers.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin":  "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function b64url(s: string): string {
+  const t = s.replace(/-/g, "+").replace(/_/g, "/");
+  return t + "=".repeat((4 - t.length % 4) % 4);
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+const err = (msg: string, status = 400) => json({ error: msg }, status);
+
+interface QuestDef {
+  id:              string;
+  name:            string;
+  rarity:          string;
+  type:            string;
+  mutation:        string | null;
+  gems:            number;
+  xp:              number;
+  validSpeciesIds: string[];
+}
+
+interface InventoryItem {
+  speciesId: string;
+  isSeed:    boolean;
+  mutation:  string | null;
+  quantity:  number;
+}
+
+Deno.serve(async (req: Request) => {
+  initSentry();
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  try {
+    // ── Auth ──────────────────────────────────────────────────────────────────
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) return err("Unauthorized", 401);
+
+    const token = authHeader.replace("Bearer ", "");
+    let userId: string;
+    try {
+      userId = JSON.parse(atob(b64url(token.split(".")[1]))).sub;
+    } catch {
+      return err("Unauthorized", 401);
+    }
+
+    // ── Parse body ────────────────────────────────────────────────────────────
+    const { eventId, questId, speciesId, mutation } =
+      await req.json() as { eventId?: string; questId?: string; speciesId?: string; mutation?: string | null };
+    if (!eventId)   return err("eventId is required");
+    if (!questId)   return err("questId is required");
+    if (!speciesId) return err("speciesId is required");
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    // ── Verify auth ───────────────────────────────────────────────────────────
+    const { data: { user }, error: authErr } = await supabase.auth.getUser(token);
+    if (authErr || !user || user.id !== userId) return err("Unauthorized", 401);
+
+    // ── Load + validate event ─────────────────────────────────────────────────
+    const event = await loadEvent(supabase, eventId);
+    if (event.type !== "collection") return err("Event is not a collection event");
+
+    // ── Resolve quest ─────────────────────────────────────────────────────────
+    const quests     = event.config.quests as QuestDef[];
+    const questIndex = quests.findIndex((q) => q.id === questId);
+    if (questIndex < 0) return err("Quest not found");
+    const quest = quests[questIndex];
+
+    // ── Load progress + enforce sequential order ───────────────────────────────
+    const progress        = await loadProgress(supabase, userId, eventId);
+    const completedQuests = progress.completedQuests ?? [];
+    const claimedRewards  = progress.claimedRewards  ?? [];
+
+    if (completedQuests.includes(questId)) return err("Quest already completed", 409);
+
+    const prevIncomplete = quests
+      .slice(0, questIndex)
+      .some((q) => !completedQuests.includes(q.id));
+    if (prevIncomplete) return err("Complete previous quests first", 409);
+
+    // ── Load game_saves ───────────────────────────────────────────────────────
+    const { data: save, error: se } = await supabase
+      .from("game_saves")
+      .select("inventory, gems, gardener_level, gardener_xp, updated_at")
+      .eq("user_id", userId)
+      .single();
+    if (se || !save) return err("Save not found", 404);
+
+    const inventory      = [...((save.inventory      as InventoryItem[]) ?? [])];
+    const priorUpdatedAt = save.updated_at    as string;
+    const gems           = (save.gems         as number) ?? 0;
+    const gardenerLevel  = (save.gardener_level as number) ?? 1;
+    const gardenerXp     = (save.gardener_xp   as number) ?? 0;
+
+    // ── Validate submitted flower ─────────────────────────────────────────────
+    // speciesId must be in the quest's allow-list (validates rarity + type server-side)
+    if (!quest.validSpeciesIds.includes(speciesId)) {
+      return err("This flower does not meet the quest requirement");
+    }
+
+    // mutation must match quest requirement (null = any mutation accepted)
+    const submittedMutation = mutation ?? null;
+    if (quest.mutation !== null && submittedMutation !== quest.mutation) {
+      return err("Flower mutation does not match quest requirement");
+    }
+
+    // Player must have at least 1 matching bloom in inventory
+    const itemIdx = inventory.findIndex((i) =>
+      !i.isSeed &&
+      i.speciesId === speciesId &&
+      i.mutation  === submittedMutation &&
+      i.quantity  > 0,
+    );
+    if (itemIdx < 0) return err("Matching flower not found in inventory", 409);
+
+    // ── Deduct flower ─────────────────────────────────────────────────────────
+    const item = inventory[itemIdx];
+    if (item.quantity === 1) {
+      inventory.splice(itemIdx, 1);
+    } else {
+      inventory[itemIdx] = { ...item, quantity: item.quantity - 1 };
+    }
+
+    // ── Award XP + gems ───────────────────────────────────────────────────────
+    const { level: newLevel, xp: newXp } = awardXp(gardenerLevel, gardenerXp, quest.xp);
+    const newGems = gems + quest.gems;
+
+    // ── Final reward — deliver exclusive seed if this is the last quest ────────
+    const isLastQuest           = questIndex === quests.length - 1;
+    let   finalRewardDelivered  = false;
+
+    if (isLastQuest) {
+      const finalReward = event.config.finalReward as { speciesId: string };
+      const seedIdx     = inventory.findIndex((i) => i.isSeed && i.speciesId === finalReward.speciesId);
+      if (seedIdx >= 0) {
+        inventory[seedIdx] = { ...inventory[seedIdx], quantity: inventory[seedIdx].quantity + 1 };
+      } else {
+        inventory.push({ speciesId: finalReward.speciesId, isSeed: true, mutation: null, quantity: 1 });
+      }
+      finalRewardDelivered = true;
+    }
+
+    // ── CAS write to game_saves ───────────────────────────────────────────────
+    const { data: ud, error: ue } = await supabase
+      .from("game_saves")
+      .update({
+        inventory:      inventory,
+        gems:           newGems,
+        gardener_level: newLevel,
+        gardener_xp:    newXp,
+        updated_at:     new Date().toISOString(),
+      })
+      .eq("user_id", userId)
+      .eq("updated_at", priorUpdatedAt)
+      .select("updated_at")
+      .single();
+    if (ue || !ud) return err("Save conflict — please retry", 409);
+
+    // ── Persist progress ──────────────────────────────────────────────────────
+    const newProgress = {
+      ...progress,
+      completedQuests: [...completedQuests, questId],
+      claimedRewards:  [...claimedRewards,  questId],
+    };
+    await saveProgress(supabase, userId, eventId, newProgress);
+
+    // ── Audit log ─────────────────────────────────────────────────────────────
+    void supabase.from("action_log").insert({
+      user_id: userId, action: "event_quest_submit",
+      payload: { eventId, questId, speciesId, mutation: submittedMutation, gemsGained: quest.gems, xpGained: quest.xp, finalRewardDelivered },
+    });
+
+    return json({
+      ok:                   true,
+      questId,
+      gemsGained:           quest.gems,
+      xpGained:             quest.xp,
+      finalRewardDelivered,
+      inventory,
+      progress:             newProgress,
+      gardenerLevel:        newLevel,
+      gardenerXp:           newXp,
+      gems:                 newGems,
+      serverUpdatedAt:      ud.updated_at,
+    });
+
+  } catch (e) {
+    if (typeof e === "string") return err(e);
+    console.error("event-quest-submit error:", e);
+    Sentry.captureException(e);
+    await Sentry.flush(2000);
+    return err("Internal server error", 500);
+  }
+});

--- a/supabase/migrations/20260508000019_events.sql
+++ b/supabase/migrations/20260508000019_events.sql
@@ -1,0 +1,47 @@
+-- ── events ────────────────────────────────────────────────────────────────────
+-- One row per event instance. Rows are inserted manually via Supabase Studio —
+-- no admin UI needed. type is an open string ("checkin", "collection", etc.)
+-- so new event types never require a schema change.
+
+CREATE TABLE IF NOT EXISTS events (
+  id          TEXT        PRIMARY KEY,
+  type        TEXT        NOT NULL,
+  name        TEXT        NOT NULL,
+  description TEXT        NOT NULL DEFAULT '',
+  starts_at   TIMESTAMPTZ NOT NULL,
+  ends_at     TIMESTAMPTZ NOT NULL,
+  config      JSONB       NOT NULL DEFAULT '{}',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── event_progress ────────────────────────────────────────────────────────────
+-- One row per (user, event). Progress shape varies by event type:
+--   checkin:    { claimedDays: number[], lastClaimedAt: string }
+--   collection: { completedQuests: string[], claimedRewards: string[] }
+
+CREATE TABLE IF NOT EXISTS event_progress (
+  user_id    UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_id   TEXT        NOT NULL REFERENCES events(id)     ON DELETE CASCADE,
+  progress   JSONB       NOT NULL DEFAULT '{}',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, event_id)
+);
+
+-- ── RLS ───────────────────────────────────────────────────────────────────────
+
+ALTER TABLE events         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE event_progress ENABLE ROW LEVEL SECURITY;
+
+-- Anyone authenticated can read events (needed to render the Events tab)
+CREATE POLICY "events_select" ON events
+  FOR SELECT TO authenticated USING (true);
+
+-- Users can only read and write their own progress rows
+CREATE POLICY "event_progress_select" ON event_progress
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+
+CREATE POLICY "event_progress_insert" ON event_progress
+  FOR INSERT TO authenticated WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "event_progress_update" ON event_progress
+  FOR UPDATE TO authenticated USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- Adds an extensible event system with two types for v1: **check-in** (7-day daily gem rewards) and **collection** (ordered flower submission quests with an exclusive final reward)
- New `events` and `event_progress` DB tables with RLS; events load separately from `game_saves` so the save schema is untouched
- `sakura_blossom` added as the first event-exclusive flower (`eventOnly: true`), awarded as the final reward for the Sakura Festival collection event
- Two new Supabase edge functions (`event-checkin-claim`, `event-quest-submit`) with full server-side validation, CAS writes, and audit logging
- `EventsTab` now has three sub-tabs: Events, Daily Tasks, Achievements. New event types only need a card component + one registry entry to appear automatically
## Test plan
- [ ] Both edge functions deploy cleanly (`event-checkin-claim`, `event-quest-submit`)
- [ ] Event rows seeded in DB; both cards render in the Events tab
- [ ] Check-in: claim Day 1, verify gems update and day grid reflects claimed state; "Come back tomorrow" shown after claim
- [ ] Collection: bloom picker filters to eligible inventory items only; submitting deducts the flower, awards gems + XP
- [ ] Collection: completing all 4 quests delivers the sakura_blossom seed and shows the final reward toast
- [ ] Sequential quest guard: cannot submit quest 2 before quest 1 is complete (409 from server)
- [ ] CAS conflict: simultaneous tab writes return 409 "Save conflict — please retry"
- [ ] Unknown event type gracefully renders nothing (no crash)